### PR TITLE
Fixed : hegel was not serving http requests

### DIFF
--- a/main.go
+++ b/main.go
@@ -161,7 +161,6 @@ func main() {
 
 	hegel.RegisterHegelServer(grpcServer, hegelServer)
 
-	logger.Info("serving grpc")
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
 	if err != nil {
 		err = errors.Wrap(err, "failed to listen")
@@ -169,10 +168,6 @@ func main() {
 		panic(err)
 	}
 
-	err = grpcServer.Serve(lis)
-	if err != nil {
-		logger.Fatal(err, "Failed to serve  grpc")
-	}
 
 	// Register grpc prometheus server
 	grpc_prometheus.Register(grpcServer)
@@ -189,4 +184,11 @@ func main() {
 			panic(err)
 		}
 	}()
+
+	//Serving GRPC
+	logger.Info("serving grpc")
+	err = grpcServer.Serve(lis)
+	if err != nil {
+		logger.Fatal(err, "Failed to serve  grpc")
+	}
 }


### PR DESCRIPTION
There was an issue in `hegel` because of which it was not able to serve any http request. Following was the issue :
When it calls to `err = grpcServer.Serve(lis)`, in the main thread/context, the main context/thread stops and wait for the grpc request to serve so the main context never reaches to call the `go routine which is responsible to serve the http request` . So that's why I moved the `err = grpcServer.Serve(lis)`  call after the `go routine of http request` is called.