### PR TITLE
Fix Docker Action migration from v1 to v2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
         version: v1.30
         args: --skip-dirs cmd/packetflow
     - name: go test
-      run: go test -v ./...    
+      run: go test -v ./...
     - name: go test coverage
       run: go test -coverprofile=coverage.txt ./...
     - name: upload codecov
@@ -41,6 +41,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [validation]
     steps:
+    - name: Docker Image Tag for Sha
+      id: docker-image-tag
+      run: |
+        echo ::set-output name=tag::quay.io/tinkerbell/hegel:latest,quay.io/tinkerbell/hegel:sha-${GITHUB_SHA::8}
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Download hegel binary
@@ -57,14 +61,12 @@ jobs:
       with:
         registry: quay.io
         username: ${{ secrets.QUAY_USERNAME }}
-        password: ${{ secrets.QUAY_PASSWORD }} 
+        password: ${{ secrets.QUAY_PASSWORD }}
     - name: quay.io/tinkerbell/hegel
       uses: docker/build-push-action@v2
       with:
         context: ./
         file: ./Dockerfile
-        registry: quay.io
-        cache-from: type=registry,ref=tinkerbell/hegel:latest
+        cache-from: type=registry,ref=quay.io/tinkerbell/hegel:latest
         push: ${{ startsWith(github.ref, 'refs/heads/master') }}
-        tags: tinkerbell/hegel:latest
-        tag_with_sha: true
+        tags: ${{ steps.docker-image-tag.outputs.tags }}


### PR DESCRIPTION
I trusted too much the green check in CI and I didn't notice the
warning:

```
Warning: Unexpected input(s) 'registry', 'tag_with_sha', valid inputs are ['builder', 'context', 'file', 'build-args', 'labels', 'tags', 'pull', 'target', 'allow', 'no-cache', 'platforms', 'load', 'push', 'outputs', 'cache-from', 'cache-to', 'secrets', 'github-token']
```

This should fix the issue as explained here https://github.com/docker/build-push-action/blob/818fbc81014f50430ad3c990e14d744b09e3b80d/UPGRADE.md#tags-with-ref-and-git-labels
