### PR TITLE
Login to quay should only work if commit is in master

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,6 +58,7 @@ jobs:
       uses: docker/setup-buildx-action@v1
     - name: Login to quay.io
       uses: docker/login-action@v1
+      if: ${{ startsWith(github.ref, 'refs/heads/master') }}
       with:
         registry: quay.io
         username: ${{ secrets.QUAY_USERNAME }}


### PR DESCRIPTION
## Description

GitHub Action environment variables gets passed to PR only if they
starts from a branch that is local, so fork does not get a QUAY PASSOWRD
and USERNAME, this is to avoid security issue.

We should push images to Quay only if the commit is in master.

