### PR TITLE
Remove site-eng from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,0 @@
-# Documentation https://help.github.com/articles/about-codeowners/
-*       @tinkerbell/site-eng


### PR DESCRIPTION
## Description

Remove site-eng team as codeowners.

## Why is this needed

This was done to ensure site-eng was watching and commenting on PRs to
avoid introducing bc-breaks that would affect EM legacy production. This
is no longer needed, and just tends to block PRs for longer than
necessary.