### PR TITLE
Replace Drone badge with GitHub Action badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-[![Build Status](https://cloud.drone.io/api/badges/tinkerbell/hegel/status.svg)](https://cloud.drone.io/tinkerbell/hegel)
+### Hegel
+
+[![Build Status](https://github.com/tinkerbell/hegel/workflows/For%20each%20commit%20and%20PR/badge.svg)](https://github.com/tinkerbell/hegel/workflows/For%20each%20commit%20and%20PR/badge.svg)
 ![](https://img.shields.io/badge/Stability-Experimental-red.svg)
 
 This repository is [Experimental](https://github.com/packethost/standards/blob/master/experimental-statement.md) meaning that it's based on untested ideas or techniques and not yet established or finalized or involves a radically new and innovative style! This means that support is best effort (at best!) and we strongly encourage you to NOT use this in production.
-
-### Hegel
 
 The gRPC and HTTP metadata service for Tinkerbell.
 Subscribe to changes in metadata, get notified when data is added/removed, etc.


### PR DESCRIPTION
Change build status badge in README from Drone to GitHub Actions

## Why is this needed

We don't use Drone any more.