### PR TITLE
Link to action runs, not the badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ### Hegel
 
-[![Build Status](https://github.com/tinkerbell/hegel/workflows/For%20each%20commit%20and%20PR/badge.svg)](https://github.com/tinkerbell/hegel/workflows/For%20each%20commit%20and%20PR/badge.svg)
+[![Build Status](https://github.com/tinkerbell/hegel/workflows/For%20each%20commit%20and%20PR/badge.svg)](https://github.com/tinkerbell/hegel/actions?query=workflow%3A%22For+each+commit+and+PR%22+branch%3Amaster)
 ![](https://img.shields.io/badge/Stability-Experimental-red.svg)
 
 This repository is [Experimental](https://github.com/packethost/standards/blob/master/experimental-statement.md) meaning that it's based on untested ideas or techniques and not yet established or finalized or involves a radically new and innovative style! This means that support is best effort (at best!) and we strongly encourage you to NOT use this in production.


### PR DESCRIPTION
No need to link to the badge itself, it is already being displayed.
Instead it makes more sense to see all the actual builds.