### PR TITLE
switch to not using root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,7 @@ EXPOSE 50061
 ENTRYPOINT ["/usr/bin/hegel"]
 
 RUN apk add --update --upgrade ca-certificates
+RUN adduser -D -u 1000 tinkerbell
+USER tinkerbell
+
 COPY --from=0 /usr/myapp/bin/hegel /usr/bin/hegel


### PR DESCRIPTION
## Description

Since it is not recommended to run docker services as root
we're switching to a newly created user `tinkerbell`.

## Why is this needed

Better security standards