### PR TITLE
Add local-hostname to metadata

### DIFF
--- a/http-server/http_handlers.go
+++ b/http-server/http_handlers.go
@@ -27,9 +27,10 @@ var (
 	ec2Filters = map[string]string{
 		"":                                    `"meta-data", "user-data"`, // base path
 		"/user-data":                          ".metadata.userdata",
-		"/meta-data":                          `["instance-id", "hostname", "iqn", "plan", "facility", "tags", "operating-system", "public-keys", "public-ipv4", "public-ipv6", "local-ipv4"] + (if .metadata.instance.spot != null then ["spot"] else [] end) | sort | .[]`,
+		"/meta-data":                          `["instance-id", "hostname", "local-hostname", "iqn", "plan", "facility", "tags", "operating-system", "public-keys", "public-ipv4", "public-ipv6", "local-ipv4"] + (if .metadata.instance.spot != null then ["spot"] else [] end) | sort | .[]`,
 		"/meta-data/instance-id":              ".metadata.instance.id",
 		"/meta-data/hostname":                 ".metadata.instance.hostname",
+		"/meta-data/local-hostname":           ".metadata.instance.hostname",
 		"/meta-data/iqn":                      ".metadata.instance.iqn",
 		"/meta-data/plan":                     ".metadata.instance.plan",
 		"/meta-data/facility":                 ".metadata.instance.facility",

--- a/http-server/http_server_test.go
+++ b/http-server/http_server_test.go
@@ -662,6 +662,7 @@ echo "Hello world!"`,
 hostname
 instance-id
 iqn
+local-hostname
 local-ipv4
 operating-system
 plan
@@ -747,6 +748,7 @@ user-data`,
 hostname
 instance-id
 iqn
+local-hostname
 local-ipv4
 operating-system
 plan
@@ -809,6 +811,7 @@ version`,
 hostname
 instance-id
 iqn
+local-hostname
 local-ipv4
 operating-system
 plan


### PR DESCRIPTION
## Description

Adds local-hostname to the ec2 style metadata output to allow for better consumption of metadata by cloud-init

## Why is this needed

When cloud-init attempts to set the hostname using the ec2 metadata source, it uses the value of local-hostname.

## How Has This Been Tested?

Ran existing test suite 

## How are existing users impacted? What migration steps/scripts do we need?

This should not affect existing users, other than those that are hitting issues with cloud-init not setting the hostname when using hegel as an ec2 metadata source.

