### PR TITLE
Run 'lint-install', address Go issues

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,54 +9,54 @@ jobs:
     env:
       CGO_ENABLED: 0
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
-    - name: Install Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: '1.14.6'
-    - name: goimports
-      run: go get golang.org/x/tools/cmd/goimports && goimports -d . | (! grep .)
-    - name: go vet
-      run: go vet ./...
-    - name: golangci-lint
-      uses: golangci/golangci-lint-action@v2
-      with:
-        version: v1.31
-        args: --skip-dirs cmd/packetflow
-    - name: go test
-      run: go test -v ./...
-    - name: go test coverage
-      run: go test -coverprofile=coverage.txt ./...
-    - name: upload codecov
-      run: bash <(curl -s https://codecov.io/bash)
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: "1.14.6"
+      - name: goimports
+        run: go get golang.org/x/tools/cmd/goimports && goimports -d . | (! grep .)
+      - name: go vet
+        run: go vet ./...
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: v1.31
+          args: --skip-dirs cmd/packetflow
+      - name: go test
+        run: go test -v ./...
+      - name: go test coverage
+        run: go test -coverprofile=coverage.txt ./...
+      - name: upload codecov
+        run: bash <(curl -s https://codecov.io/bash)
   docker-images:
     runs-on: ubuntu-latest
     needs: [validation]
     steps:
-    - name: Docker Image Tag for Sha
-      id: docker-image-tag
-      run: |
-        echo ::set-output name=tags::quay.io/tinkerbell/hegel:latest,quay.io/tinkerbell/hegel:sha-${GITHUB_SHA::8}
-    - name: Checkout code
-      uses: actions/checkout@v2
-    - name: Login to quay.io
-      uses: docker/login-action@v1
-      if: ${{ startsWith(github.ref, 'refs/heads/main') }}
-      with:
-        registry: quay.io
-        username: ${{ secrets.QUAY_USERNAME }}
-        password: ${{ secrets.QUAY_PASSWORD }}
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
-    - name: quay.io/tinkerbell/hegel
-      uses: docker/build-push-action@v2
-      with:
-        context: ./
-        file: ./cmd/hegel/Dockerfile
-        cache-from: type=registry,ref=quay.io/tinkerbell/hegel:latest
-        push: ${{ startsWith(github.ref, 'refs/heads/main') }}
-        tags: ${{ steps.docker-image-tag.outputs.tags }}
-        platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
+      - name: Docker Image Tag for Sha
+        id: docker-image-tag
+        run: |
+          echo ::set-output name=tags::quay.io/tinkerbell/hegel:latest,quay.io/tinkerbell/hegel:sha-${GITHUB_SHA::8}
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Login to quay.io
+        uses: docker/login-action@v1
+        if: ${{ startsWith(github.ref, 'refs/heads/main') }}
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: quay.io/tinkerbell/hegel
+        uses: docker/build-push-action@v2
+        with:
+          context: ./
+          file: ./cmd/hegel/Dockerfile
+          cache-from: type=registry,ref=quay.io/tinkerbell/hegel:latest
+          push: ${{ startsWith(github.ref, 'refs/heads/main') }}
+          tags: ${{ steps.docker-image-tag.outputs.tags }}
+          platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,16 +14,13 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: "1.14.6"
+          go-version: "1.17.1"
       - name: goimports
         run: go get golang.org/x/tools/cmd/goimports && goimports -d . | (! grep .)
       - name: go vet
         run: go vet ./...
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
-        with:
-          version: v1.31
-          args: --skip-dirs cmd/packetflow
+      - name: lint
+        run: make lint
       - name: go test
         run: go test -v ./...
       - name: go test coverage

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 certs/
 /cmd/hegel/hegel
 .env
+out/

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,208 @@
+run:
+  # The default runtime timeout is 1m, which doesn't work well on Github Actions.
+  timeout: 4m
+
+# NOTE: This file is populated by the lint-install tool. Local adjustments may be overwritten.
+linters-settings:
+  cyclop:
+    # NOTE: This is a very high transitional threshold
+    max-complexity: 37
+    package-average: 34.0
+    skip-tests: true
+
+  gocognit:
+    # NOTE: This is a very high transitional threshold
+    min-complexity: 98
+
+  dupl:
+    threshold: 200
+
+  goconst:
+    min-len: 4
+    min-occurrences: 5
+    ignore-tests: true
+
+  gosec:
+    excludes:
+      - G107 # Potential HTTP request made with variable url
+      - G204 # Subprocess launched with function call as argument or cmd arguments
+      - G404 # Use of weak random number generator (math/rand instead of crypto/rand
+
+  errorlint:
+    # these are still common in Go: for instance, exit errors.
+    asserts: false
+
+  exhaustive:
+    default-signifies-exhaustive: true
+
+  nestif:
+    min-complexity: 8
+
+  nolintlint:
+    require-explanation: true
+    allow-unused: false
+    require-specific: true
+
+  revive:
+    ignore-generated-header: true
+    severity: warning
+    rules:
+      - name: atomic
+      - name: blank-imports
+      - name: bool-literal-in-expr
+      - name: confusing-naming
+      - name: constant-logical-expr
+      - name: context-as-argument
+      - name: context-keys-type
+      - name: deep-exit
+      - name: defer
+      - name: range-val-in-closure
+      - name: range-val-address
+      - name: dot-imports
+      - name: error-naming
+      - name: error-return
+      - name: error-strings
+      - name: errorf
+      - name: exported
+      - name: identical-branches
+      - name: if-return
+      - name: import-shadowing
+      - name: increment-decrement
+      - name: indent-error-flow
+      - name: indent-error-flow
+      - name: package-comments
+      - name: range
+      - name: receiver-naming
+      - name: redefines-builtin-id
+      - name: superfluous-else
+      - name: struct-tag
+      - name: time-naming
+      - name: unexported-naming
+      - name: unexported-return
+      - name: unnecessary-stmt
+      - name: unreachable-code
+      - name: unused-parameter
+      - name: var-declaration
+      - name: var-naming
+      - name: unconditional-recursion
+      - name: waitgroup-by-value
+
+  staticcheck:
+    go: "1.16"
+
+  unused:
+    go: "1.16"
+
+output:
+  sort-results: true
+
+linters:
+  disable-all: true
+  enable:
+    - asciicheck
+    - bodyclose
+    - cyclop
+    - deadcode
+    - dogsled
+    - dupl
+    - durationcheck
+    - errcheck
+    # errname is only available in golangci-lint v1.42.0+ - wait until v1.43 is available to settle
+    # - errname
+    - errorlint
+    - exhaustive
+    - exportloopref
+    - forcetypeassert
+    - gocognit
+    - goconst
+    - gocritic
+    - godot
+    - gofmt
+    - gofumpt
+    - gosec
+    - goheader
+    - goimports
+    - goprintffuncname
+    - gosimple
+    - govet
+    - ifshort
+    - importas
+    - ineffassign
+    - makezero
+    - misspell
+    - nakedret
+    - nestif
+    - nilerr
+    - noctx
+    - nolintlint
+    - predeclared
+    # disabling for the initial iteration of the linting tool
+    # - promlinter
+    - revive
+    - rowserrcheck
+    - sqlclosecheck
+    - staticcheck
+    - structcheck
+    - stylecheck
+    - thelper
+    - tparallel
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - varcheck
+    - wastedassign
+    - whitespace
+
+  # Disabled linters, due to being misaligned with Go practices
+  # - exhaustivestruct
+  # - gochecknoglobals
+  # - gochecknoinits
+  # - goconst
+  # - godox
+  # - goerr113
+  # - gomnd
+  # - lll
+  # - nlreturn
+  # - testpackage
+  # - wsl
+  # Disabled linters, due to not being relevant to our code base:
+  # - maligned
+  # - prealloc "For most programs usage of prealloc will be a premature optimization."
+  # Disabled linters due to bad error messages or bugs
+  # - tagliatelle
+
+issues:
+  # Excluding configuration per-path, per-linter, per-text and per-source
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - dupl
+        - errcheck
+        - forcetypeassert
+        - gocyclo
+        - gosec
+        - noctx
+
+    - path: .*cmd.*
+      linters:
+        - noctx
+
+    - path: main\.go
+      linters:
+        - noctx
+
+    - path: .*cmd.*
+      text: "deep-exit"
+
+    - path: main\.go
+      text: "deep-exit"
+
+    # This check is of questionable value
+    - linters:
+        - tparallel
+      text: "call t.Parallel on the top level as well as its subtests"
+
+  # Don't hide lint issues just because there are many of them
+  max-same-issues: 0
+  max-issues-per-linter: 0

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,16 @@
+---
+extends: default
+
+rules:
+  braces:
+    max-spaces-inside: 1
+  brackets:
+    max-spaces-inside: 1
+  comments: disable
+  comments-indentation: disable
+  document-start: disable
+  line-length:
+    level: warning
+    max: 160
+    allow-non-breakable-inline-mappings: true
+  truthy: disable

--- a/Makefile
+++ b/Makefile
@@ -14,3 +14,49 @@ run: ${binary}
 test:
 	go test -race -coverprofile=coverage.txt -covermode=atomic ${TEST_ARGS} ./...
 endif
+
+# BEGIN: lint-install --dockerfile=warn .
+# http://github.com/tinkerbell/lint-install
+
+GOLINT_VERSION ?= v1.42.0
+HADOLINT_VERSION ?= v2.7.0
+
+YAMLLINT_VERSION ?= 1.26.3
+LINT_OS := $(shell uname)
+LINT_ARCH := $(shell uname -m)
+LINT_ROOT := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+
+# shellcheck and hadolint lack arm64 native binaries: rely on x86-64 emulation
+ifeq ($(LINT_OS),Darwin)
+	ifeq ($(LINT_ARCH),arm64)
+		LINT_ARCH=x86_64
+	endif
+endif
+
+
+GOLINT_CONFIG = $(LINT_ROOT)/.golangci.yml
+YAMLLINT_ROOT = out/linters/yamllint-$(YAMLLINT_VERSION)
+
+lint: out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH) out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH) $(YAMLLINT_ROOT)/bin/yamllint
+	out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH) run
+	out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH) --no-fail $(shell find . -name "*Dockerfile")
+	PYTHONPATH=$(YAMLLINT_ROOT)/lib $(YAMLLINT_ROOT)/bin/yamllint .
+
+fix: out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH)
+	out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH) run --fix
+
+out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH):
+	mkdir -p out/linters
+	curl -sfL https://github.com/hadolint/hadolint/releases/download/v2.6.1/hadolint-$(LINT_OS)-$(LINT_ARCH) > out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH)
+	chmod u+x out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH)
+
+out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH):
+	mkdir -p out/linters
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b out/linters $(GOLINT_VERSION)
+	mv out/linters/golangci-lint out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH)
+
+$(YAMLLINT_ROOT)/bin/yamllint:
+	mkdir -p $(YAMLLINT_ROOT)/lib
+	curl -sSfL https://github.com/adrienverge/yamllint/archive/refs/tags/v$(YAMLLINT_VERSION).tar.gz | tar -C out/linters -zxf -
+	cd $(YAMLLINT_ROOT) && PYTHONPATH=lib python setup.py -q install --prefix . --install-lib lib
+# END: lint-install --dockerfile=warn .

--- a/cmd/hegel/main.go
+++ b/cmd/hegel/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"context"
 	"flag"
-	_ "net/http/pprof"
+	_ "net/http/pprof" //nolint:gosec // G108: Profiling endpoint is automatically exposed on /debug/pprof
 	"os"
 	"os/signal"
 	"sync"
@@ -46,7 +46,7 @@ func main() {
 		logger.Fatal(err, "failed to create hegel server")
 	}
 
-	c := make(chan os.Signal)
+	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
 	var ret error
 	ctx, cancel := context.WithCancel(context.TODO())
@@ -55,7 +55,7 @@ func main() {
 	customEndpoints = env.Get("CUSTOM_ENDPOINTS", `{"/metadata":".metadata.instance"}`)
 
 	runGoroutine(&ret, cancel, &once, &wg, func() error {
-		return httpserver.Serve(ctx, logger, hegelServer, GitRev, time.Now(), customEndpoints)
+		return httpserver.Serve(logger, hegelServer, GitRev, time.Now(), customEndpoints)
 	})
 
 	runGoroutine(&ret, cancel, &once, &wg, func() error {

--- a/grpc-server/grpc_server.go
+++ b/grpc-server/grpc_server.go
@@ -223,7 +223,8 @@ func (s *Server) Subscribe(_ *hegel.SubscribeRequest, stream hegel.Hegel_Subscri
 	}
 
 	s.subLock.Lock()
-
+	// NOTE: Access to s.subscriptions must be done within this lock to avoid race conditions
+	old := s.subscriptions[id] // nolint:ifshort // variable 'old' is only used in the if-statement in :237
 	s.subscriptions[id] = sub
 	s.subLock.Unlock()
 
@@ -234,7 +235,7 @@ func (s *Server) Subscribe(_ *hegel.SubscribeRequest, stream hegel.Hegel_Subscri
 	)
 
 	// Disconnect previous client if a client is already connected for this hardware id
-	if old := s.subscriptions[id]; old != nil {
+	if old != nil {
 		old.cancel()
 	}
 

--- a/grpc-server/grpc_server_test.go
+++ b/grpc-server/grpc_server_test.go
@@ -18,11 +18,11 @@ import (
 )
 
 func TestGetCacher(t *testing.T) {
+	dataModelVersion := os.Getenv("DATA_MODEL_VERSION")
+	defer os.Setenv("DATA_MODEL_VERSION", dataModelVersion)
+
 	for name, test := range cacherGrpcTests {
 		t.Log(name)
-
-		dataModelVersion := os.Getenv("DATA_MODEL_VERSION")
-		defer os.Setenv("DATA_MODEL_VERSION", dataModelVersion)
 		os.Unsetenv("DATA_MODEL_VERSION")
 
 		l, err := log.Init("github.com/tinkerbell/hegel")
@@ -34,7 +34,6 @@ func TestGetCacher(t *testing.T) {
 		hegelTestServer, err := NewServer(logger, mock.HardwareClient{Data: test.json})
 		if err != nil {
 			t.Fatal(err, "failed to create hegel server")
-
 		}
 		addr, err := net.ResolveTCPAddr("tcp", mock.UserIP+":80")
 		if err != nil {
@@ -49,7 +48,7 @@ func TestGetCacher(t *testing.T) {
 		}
 		t.Log(ehw.JSON)
 
-		hw := hardware.ExportedHardwareCacher{}
+		hw := hardware.ExportedCacher{}
 		err = json.Unmarshal([]byte(ehw.JSON), &hw)
 		if test.error != "" {
 			if err == nil {
@@ -181,7 +180,7 @@ func TestGetByIPTinkerbell(t *testing.T) {
 	}
 }
 
-// test cases for TestGetByIPCacher
+// test cases for TestGetByIPCacher.
 var cacherGrpcTests = map[string]struct {
 	id               string
 	state            string
@@ -259,7 +258,7 @@ var cacherGrpcTests = map[string]struct {
 	},
 }
 
-// test cases for TestGetByIPTinkerbell
+// test cases for TestGetByIPTinkerbell.
 var tinkerbellGrpcTests = map[string]struct {
 	id               string
 	state            string
@@ -320,14 +319,14 @@ func TestServer_SubLock(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := &Server{subLock: tt.subLock}
-			retval_lock := s.SubLock()
-			if retval_lock == nil {
+			retvalLock := s.SubLock()
+			if retvalLock == nil {
 				t.Errorf("Server.SubLock() lock failed")
 			}
 
 			mutex.Unlock()
-			retval_unlock := s.SubLock()
-			if retval_unlock == nil {
+			retvalUnlock := s.SubLock()
+			if retvalUnlock == nil {
 				t.Errorf("Server.SubLock() unlock failed")
 			}
 		})
@@ -352,21 +351,18 @@ func TestServer_SetHardwareClient(t *testing.T) {
 			if retval == nil {
 				t.Error("Server.SetHardwareClient() failed")
 			}
-
 		})
-
 	}
 }
 
 func TestServer_Subscriptions(t *testing.T) {
-
 	tests := []struct {
 		name string
-		sub  map[string]*subscription
+		sub  map[string]*Subscription
 	}{
 		{
 			name: "test_subscription",
-			sub:  make(map[string]*subscription),
+			sub:  make(map[string]*Subscription),
 		},
 	}
 	for _, tt := range tests {

--- a/hardware/export.go
+++ b/hardware/export.go
@@ -2,9 +2,9 @@ package hardware
 
 import "encoding/json"
 
-// ExportedHardwareCacher is the structure in which hegel returns to clients using the old cacher data model
-// exposes only certain fields of the hardware data returned by cacher
-type ExportedHardwareCacher struct {
+// ExportedCacher is the structure in which hegel returns to clients using the old cacher data model
+// exposes only certain fields of the hardware data returned by cacher.
+type ExportedCacher struct {
 	ID                                 string                   `json:"id"`
 	Arch                               string                   `json:"arch"`
 	State                              string                   `json:"state"`
@@ -94,21 +94,23 @@ type storage struct {
 	Filesystems []*filesystem `json:"filesystems,omitempty"`
 }
 
-// UnmarshalJSON implements the json.Unmarshaler interface for custom unmarshalling of ExportedHardwareCacher
-func (eh *ExportedHardwareCacher) UnmarshalJSON(b []byte) error {
-	type ehj ExportedHardwareCacher
+// UnmarshalJSON implements the json.Unmarshaler interface for custom unmarshalling of ExportedCacher.
+func (eh *ExportedCacher) UnmarshalJSON(b []byte) error {
+	type ehj ExportedCacher
 	var tmp ehj
-	err := json.Unmarshal(b, &tmp)
-	if err != nil {
+
+	if err := json.Unmarshal(b, &tmp); err != nil {
 		return err
 	}
+
 	networkPorts := []map[string]interface{}{}
 	for _, port := range tmp.NetworkPorts {
 		if port["type"] == "data" {
 			networkPorts = append(networkPorts, port)
 		}
 	}
+
 	tmp.NetworkPorts = networkPorts
-	*eh = ExportedHardwareCacher(tmp)
+	*eh = ExportedCacher(tmp)
 	return nil
 }

--- a/hardware/mock/mock.go
+++ b/hardware/mock/mock.go
@@ -11,14 +11,13 @@ import (
 	"google.golang.org/grpc"
 )
 
-// HardwareClient is a mock implentation of the hardwareGetter interface
-// Data represents the hardware data stored inside tink db
+// HardwareClient is a mock implementation of the hardwareGetter interface
+// Data represents the hardware data stored inside tink db.
 type HardwareClient struct {
 	Data string
 }
 
-func (hg HardwareClient) All(ctx context.Context, opts ...grpc.CallOption) (hardware.AllClient, error) {
-	// TODO (kdeng3849)
+func (hg HardwareClient) All(_ context.Context, _ ...grpc.CallOption) (hardware.AllClient, error) {
 	return nil, nil
 }
 
@@ -27,12 +26,12 @@ func (hg HardwareClient) All(ctx context.Context, opts ...grpc.CallOption) (hard
 // having to parse the (mock) hardware data `HardwareClient.Data`, the process has been simplified to only match with the constant `UserIP`.
 // Given any other IP inside the get request, ByIP will return an empty piece of hardware regardless of whether or not the IP
 // actually matches the IP inside `Data`.
-func (hg HardwareClient) ByIP(ctx context.Context, ip string, opts ...grpc.CallOption) (hardware.Hardware, error) {
+func (hg HardwareClient) ByIP(_ context.Context, ip string, _ ...grpc.CallOption) (hardware.Hardware, error) {
 	var hw hardware.Hardware
 	dataModelVersion := os.Getenv("DATA_MODEL_VERSION")
 	switch dataModelVersion {
 	case "1":
-		hw = &hardware.HardwareTinkerbell{}
+		hw = &hardware.Tinkerbell{}
 
 		if ip != UserIP {
 			return hw, errors.New("rpc error: code = Unknown desc = unexpected end of JSON input")
@@ -44,17 +43,16 @@ func (hg HardwareClient) ByIP(ctx context.Context, ip string, opts ...grpc.CallO
 		}
 	default:
 		if ip != UserIP {
-			return &hardware.HardwareCacher{}, errors.New("rpc error: code = Unknown desc = DB is not ready")
+			return &hardware.Cacher{}, errors.New("rpc error: code = Unknown desc = DB is not ready")
 		}
 
-		hw = &hardware.HardwareCacher{Hardware: &cacher.Hardware{JSON: hg.Data}}
+		hw = &hardware.Cacher{Hardware: &cacher.Hardware{JSON: hg.Data}}
 	}
 
 	return hw, nil
 }
 
-func (hg HardwareClient) Watch(ctx context.Context, id string, opts ...grpc.CallOption) (hardware.Watcher, error) {
-	// TODO (kdeng3849)
+func (hg HardwareClient) Watch(_ context.Context, _ string, _ ...grpc.CallOption) (hardware.Watcher, error) {
 	return nil, nil
 }
 
@@ -391,6 +389,6 @@ const (
 		}
 	  }
 `
-	// tinkerbellFilterMetadata is used for testing the filterMetadata function and has the 'metadata' field represented as an object (as opposed to string)
+	// tinkerbellFilterMetadata is used for testing the filterMetadata function and has the 'metadata' field represented as an object (as opposed to string).
 	TinkerbellFilterMetadata = `{"id":"0eba0bf8-3772-4b4a-ab9f-6ebe93b90a94","metadata":{"components":{"id":"bc9ce39b-7f18-425b-bc7b-067914fa9786","type":"DiskComponent"},"instance":{"api_url":"https://metadata.packet.net","class":"c3.small.x86","customdata":{},"facility":"sjc1","hostname":"tink-provisioner","id":"7c9a5711-aadd-4fa0-8e57-789431626a27","iqn":"iqn.2020-06.net.packet:device.7c9a5711","network":{"addresses":[{"address":"139.175.86.114","address_family":4,"cidr":31,"created_at":"2020-06-19T04:16:08Z","enabled":true,"gateway":"139.175.86.113","id":"99e15f8e-6eab-40db-9c6f-69a69ef9854f","management":true,"netmask":"255.255.255.254","network":"139.175.86.113","parent_block":{"cidr":31,"href":"/ips/179580b0-3ae4-4fc0-8cbe-4f34174bebb4","netmask":"255.255.255.254","network":"139.175.86.113"},"public":true},{"address":"2604:1380:1000:ca00::7","address_family":6,"cidr":127,"created_at":"2020-06-19T04:16:08Z","enabled":true,"gateway":"2604:1380:1000:ca00::6","id":"f4b24331-c6cf-4ae4-899b-e78f223b2c57","management":true,"netmask":"ffff:ffff:ffff:ffff:ffff:ffff:ffff:fffe","network":"2604:1380:1000:ca00::6","parent_block":{"cidr":56,"href":"/ips/960aa63d-eeb6-410e-8242-1d6e2e7733fc","netmask":"ffff:ffff:ffff:ff00:0000:0000:0000:0000","network":"2604:1380:1000:ca00:0000:0000:0000:0000"},"public":true},{"address":"10.87.63.3","address_family":4,"cidr":31,"created_at":"2020-06-19T04:16:08Z","enabled":true,"gateway":"10.87.63.2","id":"5cca13a9-43d0-45a6-9ed7-3d9e2fbf0e87","management":true,"netmask":"255.255.255.254","network":"10.87.63.2","parent_block":{"cidr":25,"href":"/ips/7cde0a1b-d787-4a10-9c96-4049c7d5eeb3","netmask":"255.255.255.128","network":"10.87.63.0"},"public":false}],"bonding":{"link_aggregation":null,"mac":"b4:96:91:5f:ad:d8","mode":4},"interfaces":[{"bond":"bond0","mac":"b4:96:91:5f:ad:d8","name":"eth0"},{"bond":"bond0","mac":"b4:96:91:5f:ad:d9","name":"eth1"}]},"operating_system":{"distro":"ubuntu","image_tag":"f8f0331d31935319dfa8b6d551b5680840d7944f","license_activation":{"state":"unlicensed"},"slug":"ubuntu_18_04","version":"18.04"},"phone_home_url":"http://tinkerbell.sjc1.packet.net/phone-home","plan":"c3.small.x86","private_subnets":["10.0.0.0/8"],"specs":{"cpus":[{"count":1,"type":"EPYC 3151 4 Core Processor @ 2.7GHz"}],"drives":[{"category":"boot","count":2,"size":"240GB","type":"SSD"}],"features":{},"memory":{"total":"16GB"},"nics":[{"count":2,"type":"10Gbps"}]},"spot":{},"ssh_keys":[],"storage":{"disks":[{"device":"/dev/sda","partitions":[{"label":"BIOS","number":1,"size":4096},{"label":"SWAP","number":2,"size":"3993600"},{"label":"ROOT","number":3,"size":0}],"wipeTable":true}],"filesystems":[{"mount":{"create":{"options":["-L","ROOT"]},"device":"/dev/sda3","format":"ext4","point":"/"}},{"mount":{"create":{"options":["-L","SWAP"]},"device":"/dev/sda2","format":"swap","point":"none"}}]},"switch_short_id":"68c7fa13","tags":["hello","test"],"user_state_url":"http://tinkerbell.sjc1.packet.net/events","volumes":[]},"userdata":"#!/bin/bash\n\necho \"Hello world!\""},"network":{"interfaces":[{"dhcp":{"arch":"x86_64","ip":{"address":"192.168.1.5","gateway":"192.168.1.1","netmask":"255.255.255.248"},"mac":"b4:96:91:5f:af:c0"},"netboot":{"allow_pxe":true,"allow_workflow":true}}]}}`
 )

--- a/hegelc/main.go
+++ b/hegelc/main.go
@@ -15,8 +15,11 @@ import (
 
 func main() {
 	config := &tls.Config{
-		InsecureSkipVerify: true,
+		// TODO: Investigate whether it is safe to remove this dangerous default
+		InsecureSkipVerify: true, //nolint:gosec // G402: TLS InsecureSkipVerify set true
 	}
+
+	// TODO: Remove this hard-coded hostname
 	conn, err := grpc.Dial("metadata.packet.net:50060", grpc.WithTransportCredentials(credentials.NewTLS(config)))
 	if err != nil {
 		log.Panic(err)
@@ -49,7 +52,7 @@ func subscribe(ctx context.Context, client hegel.HegelClient, onJSON func(string
 
 	for {
 		hw, err := watcher.Recv()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			return errors.New("hegel closed the subscription")
 		}
 

--- a/http-server/http_server.go
+++ b/http-server/http_server.go
@@ -30,7 +30,7 @@ var (
 	hegelServer                 *grpcserver.Server
 )
 
-func Serve(ctx context.Context, l log.Logger, srv *grpcserver.Server, gRev string, t time.Time, customEndpoints string) error {
+func Serve(l log.Logger, srv *grpcserver.Server, gRev string, t time.Time, customEndpoints string) error {
 	startTime = t
 	gitRev = gRev
 	logger = l
@@ -52,7 +52,7 @@ func Serve(ctx context.Context, l log.Logger, srv *grpcserver.Server, gRev strin
 	mux.Handle("/2009-04-04", ec2hf) // workaround for making trailing slash optional
 	mux.Handle("/2009-04-04/", ec2hf)
 
-	buildSubscriberHandlers(hegelServer)
+	buildSubscriberHandlers()
 
 	err := registerCustomEndpoints(mux, customEndpoints)
 	if err != nil {

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -42,7 +42,7 @@ func Init(_ log.Logger) {
 
 	InitDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "hegel_subscription_initialization_duration_seconds",
-		Help:    "Duration taken to get a responce for a newly discovered request.",
+		Help:    "Duration taken to get a response for a newly discovered request.",
 		Buckets: []float64{0.5, 1, 5, 10, 30, 60},
 	}, []string{}).With(prometheus.Labels{})
 


### PR DESCRIPTION
Signed-off-by: Thomas Stromberg <t+github@stromberg.org>

## Description

Fixes the following lint issues:

```
cmd/hegel/main.go:6:2: G108: Profiling endpoint is automatically exposed on /debug/pprof (gosec)
	_ "net/http/pprof"
	^
cmd/hegel/main.go:50:2: sigchanyzer: misuse of unbuffered os.Signal channel as argument to signal.Notify (govet)
	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
	^
grpc-server/grpc_server.go:74:12: unused-parameter: parameter 'ctx' seems to be unused, consider removing or renaming it as _ (revive)
func Serve(ctx context.Context, l log.Logger, srv *Server) error {
           ^
grpc-server/grpc_server.go:122:2: commentFormatting: put a space between `//` and comment text (gocritic)
	//Serving GRPC
	^
grpc-server/grpc_server.go:144:34: unexported-return: exported method Subscriptions returns unexported type map[string]*grpcserver.subscription, which can be annoying to use (revive)
func (s *Server) Subscriptions() map[string]*subscription {
                                 ^
grpc-server/grpc_server.go:152:43: unused-parameter: parameter 'in' seems to be unused, consider removing or renaming it as _ (revive)
func (s *Server) Get(ctx context.Context, in *hegel.GetRequest) (*hegel.GetResponse, error) {
                                          ^
grpc-server/grpc_server.go:173:28: unused-parameter: parameter 'in' seems to be unused, consider removing or renaming it as _ (revive)
func (s *Server) Subscribe(in *hegel.SubscribeRequest, stream hegel.Hegel_SubscribeServer) error {
                           ^
grpc-server/grpc_server.go:200: File is not `gofumpt`-ed (gofumpt)

grpc-server/grpc_server.go:212: File is not `gofumpt`-ed (gofumpt)

grpc-server/grpc_server.go:228:2: variable 'old' is only used in the if-statement (grpc-server/grpc_server.go:239:2); consider using short syntax (ifshort)
	old := s.subscriptions[id]
	^
grpc-server/grpc_server.go:259:4: error is nil (line 257) but it returns error (nilerr)
			return err
			^
grpc-server/grpc_server.go:272:8: comparing with == will fail on wrapped errors. Use errors.Is to check for a specific error (errorlint)
				if err == io.EOF {
				   ^
grpc-server/grpc_server.go:297: File is not `gofumpt`-ed (gofumpt)

grpc-server/grpc_server.go:304: File is not `gofumpt`-ed (gofumpt)

grpc-server/grpc_server_test.go:25:3: defer: prefer not to defer inside loops (revive)
		defer os.Setenv("DATA_MODEL_VERSION", dataModelVersion)
		^
grpc-server/grpc_server_test.go:37: File is not `gofumpt`-ed (gofumpt)

grpc-server/grpc_server_test.go:184:36: Comment should end in a period (godot)
// test cases for TestGetByIPCacher
                                   ^
grpc-server/grpc_server_test.go:262:40: Comment should end in a period (godot)
// test cases for TestGetByIPTinkerbell
                                       ^
grpc-server/grpc_server_test.go:323:4: var-naming: don't use underscores in Go names; var retval_lock should be retvalLock (revive)
			retval_lock := s.SubLock()
			^
grpc-server/grpc_server_test.go:329:4: var-naming: don't use underscores in Go names; var retval_unlock should be retvalUnlock (revive)
			retval_unlock := s.SubLock()
			^
grpc-server/grpc_server_test.go:355: File is not `gofumpt`-ed (gofumpt)

grpc-server/grpc_server_test.go:357: File is not `gofumpt`-ed (gofumpt)

grpc-server/grpc_server_test.go:361: unnecessary leading newline (whitespace)
func TestServer_Subscriptions(t *testing.T) {

grpc-server/grpc_server_test.go:362: File is not `gofumpt`-ed (gofumpt)

hardware/client.go:23:62: Comment should end in a period (godot)
// Client acts as the messenger between Hegel and Cacher/Tink
                                                             ^
hardware/client.go:32:60: Comment should end in a period (godot)
// Hardware is the interface for Cacher/Tink hardware types
                                                           ^
hardware/client.go:38:63: Comment should end in a period (godot)
// Watcher is the interface for Cacher/Tink watch client types
                                                              ^
hardware/client.go:51:6: exported: type name will be used as hardware.HardwareCacher by other packages, and that stutters; consider calling this Cacher (revive)
type HardwareCacher struct {
     ^
hardware/client.go:55:6: exported: type name will be used as hardware.HardwareTinkerbell by other packages, and that stutters; consider calling this Tinkerbell (revive)
type HardwareTinkerbell struct {
     ^
hardware/client.go:67:128: Comment should end in a period (godot)
// NewClient returns a new hardware Client, configured appropriately according to the mode (Cacher or Tink) Hegel is running in
                                                                                                                               ^
hardware/client.go:89:61: Comment should end in a period (godot)
// All retrieves all the pieces of hardware stored in Cacher
                                                            ^
hardware/client.go:99:74: Comment should end in a period (godot)
// ByIP retrieves from Cacher the piece of hardware with the specified IP
                                                                         ^
hardware/client.go:111:77: Comment should end in a period (godot)
// Watch returns a Cacher watch client on the hardware with the specified ID
                                                                            ^
hardware/client.go:123:61: Comment should end in a period (godot)
// All retrieves all the pieces of hardware stored in Cacher
                                                            ^
hardware/client.go:133:72: Comment should end in a period (godot)
// ByIP retrieves from Tink the piece of hardware with the specified IP
                                                                       ^
hardware/client.go:145:75: Comment should end in a period (godot)
// Watch returns a Tink watch client on the hardware with the specified ID
                                                                          ^
hardware/client.go:157:79: Comment should end in a period (godot)
// Export formats the piece of hardware to be returned in responses to clients
                                                                              ^
hardware/client.go:168:30: Comment should end in a period (godot)
// ID returns the hardware ID
                             ^
hardware/client.go:177:2: type assertion must be checked (forcetypeassert)
	id := hwID.(string)
	^
hardware/client.go:182:79: Comment should end in a period (godot)
// Export formats the piece of hardware to be returned in responses to clients
                                                                              ^
hardware/client.go:187:30: Comment should end in a period (godot)
// ID returns the hardware ID
                             ^
hardware/client.go:192:66: Comment should end in a period (godot)
// Recv receives a piece of hardware from the Cacher watch client
                                                                 ^
hardware/client.go:201:64: Comment should end in a period (godot)
// Recv receives a piece of hardware from the Tink watch client
                                                               ^
hardware/export.go:6:71: Comment should end in a period (godot)
// exposes only certain fields of the hardware data returned by cacher
                                                                      ^
hardware/export.go:97:110: Comment should end in a period (godot)
// UnmarshalJSON implements the json.Unmarshaler interface for custom unmarshalling of ExportedHardwareCacher
                                                                                                             ^
hardware/export.go:101:2: variable 'err' is only used in the if-statement (hardware/export.go:102:2); consider using short syntax (ifshort)
	err := json.Unmarshal(b, &tmp)
	^
hardware/mock/mock.go:14:29: `implentation` is a misspelling of `implementation` (misspell)
// HardwareClient is a mock implentation of the hardwareGetter interface
                            ^
hardware/mock/mock.go:15:59: Comment should end in a period (godot)
// Data represents the hardware data stored inside tink db
                                                          ^
hardware/mock/mock.go:20:30: unused-parameter: parameter 'ctx' seems to be unused, consider removing or renaming it as _ (revive)
func (hg HardwareClient) All(ctx context.Context, opts ...grpc.CallOption) (hardware.AllClient, error) {
                             ^
hardware/mock/mock.go:30:31: unused-parameter: parameter 'ctx' seems to be unused, consider removing or renaming it as _ (revive)
func (hg HardwareClient) ByIP(ctx context.Context, ip string, opts ...grpc.CallOption) (hardware.Hardware, error) {
                              ^
hardware/mock/mock.go:56:32: unused-parameter: parameter 'ctx' seems to be unused, consider removing or renaming it as _ (revive)
func (hg HardwareClient) Watch(ctx context.Context, id string, opts ...grpc.CallOption) (hardware.Watcher, error) {
                               ^
hardware/mock/mock.go:394:154: Comment should end in a period (godot)
	// tinkerbellFilterMetadata is used for testing the filterMetadata function and has the 'metadata' field represented as an object (as opposed to string)
	                                                                                                                                                        ^
hegelc/main.go:18:3: G402: TLS InsecureSkipVerify set true. (gosec)
		InsecureSkipVerify: true,
		^
hegelc/main.go:52:6: comparing with == will fail on wrapped errors. Use errors.Is to check for a specific error (errorlint)
		if err == io.EOF {
		   ^
http-server/http_handlers.go:22: File is not `gofumpt`-ed (gofumpt)
var (
	// ec2Filters defines the query pattern and filters for the EC2 endpoint
	// for queries that are to return another list of metadata items, the filter is a static list of the metadata items ("directory-listing filter")
	// for /meta-data, the `spot` metadata item will only show up when the instance is a spot instance (denoted by if the `spot` field inside hardware is nonnull)
	// NOTE: make sure when adding a new metadata item in a "subdirectory", to also add it to the directory-listing filter
	ec2Filters = map[string]string{
		"":                                    `"meta-data", "user-data"`, // base path
		"/user-data":                          ".metadata.userdata",
		"/meta-data":                          `["instance-id", "hostname", "local-hostname", "iqn", "plan", "facility", "tags", "operating-system", "public-keys", "public-ipv4", "public-ipv6", "local-ipv4"] + (if .metadata.instance.spot != null then ["spot"] else [] end) | sort | .[]`,
		"/meta-data/instance-id":              ".metadata.instance.id",
		"/meta-data/hostname":                 ".metadata.instance.hostname",
		"/meta-data/local-hostname":           ".metadata.instance.hostname",
		"/meta-data/iqn":                      ".metadata.instance.iqn",
		"/meta-data/plan":                     ".metadata.instance.plan",
		"/meta-data/facility":                 ".metadata.instance.facility",
		"/meta-data/tags":                     ".metadata.instance.tags[]?",
		"/meta-data/operating-system":         `["slug", "distro", "version", "license_activation", "image_tag"] | sort | .[]`,
		"/meta-data/operating-system/slug":    ".metadata.instance.operating_system.slug",
		"/meta-data/operating-system/distro":  ".metadata.instance.operating_system.distro",
		"/meta-data/operating-system/version": ".metadata.instance.operating_system.version",
		"/meta-data/operating-system/license_activation":       `"state"`,
		"/meta-data/operating-system/license_activation/state": ".metadata.instance.operating_system.license_activation.state",
		"/meta-data/operating-system/image_tag":                ".metadata.instance.operating_system.image_tag",
		"/meta-data/public-keys":                               ".metadata.instance.ssh_keys[]?",
		"/meta-data/spot":                                      `"termination-time"`,
		"/meta-data/spot/termination-time":                     ".metadata.instance.spot.termination_time",
		"/meta-data/public-ipv4":                               ".metadata.instance.network.addresses[]? | select(.address_family == 4 and .public == true) | .address",
		"/meta-data/public-ipv6":                               ".metadata.instance.network.addresses[]? | select(.address_family == 6 and .public == true) | .address",
		"/meta-data/local-ipv4":                                ".metadata.instance.network.addresses[]? | select(.address_family == 4 and .public == false) | .address",
	}
)
http-server/http_handlers.go:26:120: Comment should end in a period (godot)
	// NOTE: make sure when adding a new metadata item in a "subdirectory", to also add it to the directory-listing filter
	                                                                                                                      ^
http-server/http_handlers.go:54:44: unused-parameter: parameter 'r' seems to be unused, consider removing or renaming it as _ (revive)
func versionHandler(w http.ResponseWriter, r *http.Request) {
                                           ^
http-server/http_handlers.go:56:5: variable 'err' is only used in the if-statement (http-server/http_handlers.go:57:2); consider using short syntax (ifshort)
	_, err := w.Write(gitRevJSON)
	   ^
http-server/http_handlers.go:62:48: unused-parameter: parameter 'r' seems to be unused, consider removing or renaming it as _ (revive)
func healthCheckHandler(w http.ResponseWriter, r *http.Request) {
                                               ^
http-server/http_handlers.go:143: unnecessary trailing newline (whitespace)

		}
http-server/http_handlers.go:252:63: Comment should end in a period (godot)
// or a comma-separated list of metadata items (to be printed)
                                                              ^
http-server/http_handlers.go:265:2: unexported-naming: the symbol IPAddress is local, its name should start with a lowercase letter (revive)
	IPAddress := r.RemoteAddr
	^
http-server/http_handlers.go:278:10: indent-error-flow: if block ends with a return statement, so drop this else and outdent its block (revive)
		} else {
			status = 500
			logger.Error(err, "failed to marshal error")
			body = []byte(`{"error", {"comment": "Failed to marshal error"}}`)
		}
http-server/http_handlers.go:321:30: unused-parameter: parameter 'hegelServer' seems to be unused, consider removing or renaming it as _ (revive)
func buildSubscriberHandlers(hegelServer *grpcserver.Server) {
                             ^
http-server/http_server.go:33:12: unused-parameter: parameter 'ctx' seems to be unused, consider removing or renaming it as _ (revive)
func Serve(ctx context.Context, l log.Logger, srv *grpcserver.Server, gRev string, t time.Time, customEndpoints string) error {
           ^
http-server/http_server_test.go:40:162: Comment should end in a period (godot)
// TestTrustedProxies tests if the actual remote user IP is extracted correctly from the X-FORWARDED-FOR header according to the list of trusted proxies provided
                                                                                                                                                                 ^
http-server/http_server_test.go:89:3: defer: prefer not to defer inside loops (revive)
		defer os.Setenv("DATA_MODEL_VERSION", dataModelVersion)
		^
http-server/http_server_test.go:124:75: Comment should end in a period (godot)
// TestGetMetadataTinkerbell tests the default use case in tinkerbell mode
                                                                          ^
http-server/http_server_test.go:175:85: Comment should end in a period (godot)
// TestGetMetadataTinkerbellKant tests the kant specific use case in tinkerbell mode
                                                                                    ^
http-server/http_server_test.go:299: unnecessary leading newline (whitespace)
		t.Run(name, func(t *testing.T) {

http-server/http_server_test.go:300: File is not `gofumpt`-ed (gofumpt)

http-server/http_server_test.go:319: unnecessary leading newline (whitespace)
		t.Run(name, func(t *testing.T) {

http-server/http_server_test.go:320: File is not `gofumpt`-ed (gofumpt)

http-server/http_server_test.go:339:102: Comment should end in a period (godot)
// itemsFromFilter are the metadata items "extracted" from the filters (values) of the ec2Filters map
                                                                                                     ^
http-server/http_server_test.go:352: unnecessary leading newline (whitespace)
		t.Run(basePath, func(t *testing.T) {

http-server/http_server_test.go:353: File is not `gofumpt`-ed (gofumpt)

http-server/http_server_test.go:374:37: Comment should end in a period (godot)
// test cases for TestTrustedProxies
                                    ^
http-server/http_server_test.go:494:40: Comment should end in a period (godot)
// test cases for TestGetMetadataCacher
                                       ^
http-server/http_server_test.go:507:44: Comment should end in a period (godot)
// test cases for TestGetMetadataTinkerbell
                                           ^
http-server/http_server_test.go:510:2: var-naming: don't use underscores in Go names; struct field crypted_root_password should be cryptedRootPassword (revive)
	crypted_root_password string
	^
http-server/http_server_test.go:525:48: Comment should end in a period (godot)
// test cases for TestGetMetadataTinkerbellKant
                                               ^
http-server/http_server_test.go:560:40: Comment should end in a period (godot)
// test cases for TestRegisterEndpoints
                                       ^
http-server/http_server_test.go:643:34: Comment should end in a period (godot)
// test cases for TestEC2Endpoint
                                 ^
http-server/http_server_test.go:770:37: Comment should end in a period (godot)
// test cases for TestFilterMetadata
                                    ^
http-server/http_server_test.go:857:38: Comment should end in a period (godot)
// test cases for TestProcessEC2Query
                                     ^
http-server/http_server_test.go:899: unnecessary leading newline (whitespace)
func TestServe(t *testing.T) {

http-server/http_server_test.go:900: File is not `gofumpt`-ed (gofumpt)

http-server/http_server_test.go:930: unnecessary leading newline (whitespace)
		t.Run(tt.name, func(t *testing.T) {

http-server/http_server_test.go:931: File is not `gofumpt`-ed (gofumpt)

http-server/http_server_test.go:936:38: response body must be closed (bodyclose)
			resp, err := http.DefaultClient.Do(req)
			                                  ^
metrics/metrics.go:45:37: `responce` is a misspelling of `response` (misspell)
		Help:    "Duration taken to get a responce for a newly discovered request.",
		                                  ^
xff/xff.go:52:2: type assertion must be checked (forcetypeassert)
	tcpAddr := remote.Addr.(*net.TCPAddr)
	^
xff/xff.go:57:9: import-shadowing: The name 'net' shadows an import name (revive)
	for _, net := range masks {
	       ^
xff/xff.go:70:9: import-shadowing: The name 'xff' shadows an import name (revive)
	for _, xff := range xffs {
	       ^
xff/xff.go:107:6: assignOp: replace `cidr = cidr + "/32"` with `cidr += "/32"` (gocritic)
					cidr = cidr + "/32"
					^
xff/xff.go:109:6: assignOp: replace `cidr = cidr + "/128"` with `cidr += "/128"` (gocritic)
					cidr = cidr + "/128"
					^
xff/xff.go:151:75: Comment should end in a period (godot)
// HTTPHandler creates a XFF handler if there are allowedSubnets specified
                                                                          ^
make: *** [lint] Error 1
 !  ~/s/hegel   lint *$…  make fix                                               11.6s  Thu Sep 30 17:31:15 2021
out/linters/golangci-lint-v1.42.0-x86_64 run --fix
cmd/hegel/main.go:6:2: G108: Profiling endpoint is automatically exposed on /debug/pprof (gosec)
	_ "net/http/pprof"
	^
cmd/hegel/main.go:50:2: sigchanyzer: misuse of unbuffered os.Signal channel as argument to signal.Notify (govet)
	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
	^
grpc-server/grpc_server.go:74:12: unused-parameter: parameter 'ctx' seems to be unused, consider removing or renaming it as _ (revive)
func Serve(ctx context.Context, l log.Logger, srv *Server) error {
           ^
grpc-server/grpc_server.go:122:2: commentFormatting: put a space between `//` and comment text (gocritic)
	//Serving GRPC
	^
grpc-server/grpc_server.go:144:34: unexported-return: exported method Subscriptions returns unexported type map[string]*grpcserver.subscription, which can be annoying to use (revive)
func (s *Server) Subscriptions() map[string]*subscription {
                                 ^
grpc-server/grpc_server.go:152:43: unused-parameter: parameter 'in' seems to be unused, consider removing or renaming it as _ (revive)
func (s *Server) Get(ctx context.Context, in *hegel.GetRequest) (*hegel.GetResponse, error) {
                                          ^
grpc-server/grpc_server.go:173:28: unused-parameter: parameter 'in' seems to be unused, consider removing or renaming it as _ (revive)
func (s *Server) Subscribe(in *hegel.SubscribeRequest, stream hegel.Hegel_SubscribeServer) error {
                           ^
grpc-server/grpc_server.go:228:2: variable 'old' is only used in the if-statement (grpc-server/grpc_server.go:239:2); consider using short syntax (ifshort)
	old := s.subscriptions[id]
	^
grpc-server/grpc_server.go:259:4: error is nil (line 257) but it returns error (nilerr)
			return err
			^
grpc-server/grpc_server.go:272:8: comparing with == will fail on wrapped errors. Use errors.Is to check for a specific error (errorlint)
				if err == io.EOF {
				   ^
grpc-server/grpc_server_test.go:25:3: defer: prefer not to defer inside loops (revive)
		defer os.Setenv("DATA_MODEL_VERSION", dataModelVersion)
		^
grpc-server/grpc_server_test.go:323:4: var-naming: don't use underscores in Go names; var retval_lock should be retvalLock (revive)
			retval_lock := s.SubLock()
			^
grpc-server/grpc_server_test.go:329:4: var-naming: don't use underscores in Go names; var retval_unlock should be retvalUnlock (revive)
			retval_unlock := s.SubLock()
			^
hardware/client.go:51:6: exported: type name will be used as hardware.HardwareCacher by other packages, and that stutters; consider calling this Cacher (revive)
type HardwareCacher struct {
     ^
hardware/client.go:55:6: exported: type name will be used as hardware.HardwareTinkerbell by other packages, and that stutters; consider calling this Tinkerbell (revive)
type HardwareTinkerbell struct {
     ^
hardware/client.go:177:2: type assertion must be checked (forcetypeassert)
	id := hwID.(string)
	^
hardware/export.go:101:2: variable 'err' is only used in the if-statement (hardware/export.go:102:2); consider using short syntax (ifshort)
	err := json.Unmarshal(b, &tmp)
	^
hardware/mock/mock.go:20:30: unused-parameter: parameter 'ctx' seems to be unused, consider removing or renaming it as _ (revive)
func (hg HardwareClient) All(ctx context.Context, opts ...grpc.CallOption) (hardware.AllClient, error) {
                             ^
hardware/mock/mock.go:30:31: unused-parameter: parameter 'ctx' seems to be unused, consider removing or renaming it as _ (revive)
func (hg HardwareClient) ByIP(ctx context.Context, ip string, opts ...grpc.CallOption) (hardware.Hardware, error) {
                              ^
hardware/mock/mock.go:56:32: unused-parameter: parameter 'ctx' seems to be unused, consider removing or renaming it as _ (revive)
func (hg HardwareClient) Watch(ctx context.Context, id string, opts ...grpc.CallOption) (hardware.Watcher, error) {
                               ^
hegelc/main.go:18:3: G402: TLS InsecureSkipVerify set true. (gosec)
		InsecureSkipVerify: true,
		^
hegelc/main.go:52:6: comparing with == will fail on wrapped errors. Use errors.Is to check for a specific error (errorlint)
		if err == io.EOF {
		   ^
http-server/http_handlers.go:54:44: unused-parameter: parameter 'r' seems to be unused, consider removing or renaming it as _ (revive)
func versionHandler(w http.ResponseWriter, r *http.Request) {
                                           ^
http-server/http_handlers.go:56:5: variable 'err' is only used in the if-statement (http-server/http_handlers.go:57:2); consider using short syntax (ifshort)
	_, err := w.Write(gitRevJSON)
	   ^
http-server/http_handlers.go:62:48: unused-parameter: parameter 'r' seems to be unused, consider removing or renaming it as _ (revive)
func healthCheckHandler(w http.ResponseWriter, r *http.Request) {
                                               ^
http-server/http_handlers.go:265:2: unexported-naming: the symbol IPAddress is local, its name should start with a lowercase letter (revive)
	IPAddress := r.RemoteAddr
	^
http-server/http_handlers.go:278:10: indent-error-flow: if block ends with a return statement, so drop this else and outdent its block (revive)
		} else {
			status = 500
			logger.Error(err, "failed to marshal error")
			body = []byte(`{"error", {"comment": "Failed to marshal error"}}`)
		}
http-server/http_handlers.go:321:30: unused-parameter: parameter 'hegelServer' seems to be unused, consider removing or renaming it as _ (revive)
func buildSubscriberHandlers(hegelServer *grpcserver.Server) {
                             ^
http-server/http_server.go:33:12: unused-parameter: parameter 'ctx' seems to be unused, consider removing or renaming it as _ (revive)
func Serve(ctx context.Context, l log.Logger, srv *grpcserver.Server, gRev string, t time.Time, customEndpoints string) error {
           ^
http-server/http_server_test.go:89:3: defer: prefer not to defer inside loops (revive)
		defer os.Setenv("DATA_MODEL_VERSION", dataModelVersion)
		^
http-server/http_server_test.go:510:2: var-naming: don't use underscores in Go names; struct field crypted_root_password should be cryptedRootPassword (revive)
	crypted_root_password string
	^
http-server/http_server_test.go:936:38: response body must be closed (bodyclose)
			resp, err := http.DefaultClient.Do(req)
			                                  ^
xff/xff.go:52:2: type assertion must be checked (forcetypeassert)
	tcpAddr := remote.Addr.(*net.TCPAddr)
	^
xff/xff.go:57:9: import-shadowing: The name 'net' shadows an import name (revive)
	for _, net := range masks {
	       ^
xff/xff.go:70:9: import-shadowing: The name 'xff' shadows an import name (revive)
	for _, xff := range xffs {
	       ^
xff/xff.go:107:6: assignOp: replace `cidr = cidr + "/32"` with `cidr += "/32"` (gocritic)
					cidr = cidr + "/32"
					^
xff/xff.go:109:6: assignOp: replace `cidr = cidr + "/128"` with `cidr += "/128"` (gocritic)
					cidr = cidr + "/128"
					^
make: *** [fix] Error 1

./.github/workflows/ci.yaml
  12:5      error    wrong indentation: expected 6 but found 4  (indentation)
  37:5      error    wrong indentation: expected 6 but found 4  (indentation)
```
```


## Why is this needed

https://github.com/tinkerbell/lint-install/issues/9

## How Has This Been Tested?

`go test -v ./...`