### PR TITLE
Generalize the hardware client interface

### DIFF
--- a/hardware/mock/mock.go
+++ b/hardware/mock/mock.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/packethost/cacher/protos/cacher"
 	"github.com/tinkerbell/hegel/hardware"
-	"google.golang.org/grpc"
 )
 
 // HardwareClient is a mock implementation of the hardwareGetter interface
@@ -17,8 +16,8 @@ type HardwareClient struct {
 	Data string
 }
 
-func (hg HardwareClient) All(_ context.Context, _ ...grpc.CallOption) (hardware.AllClient, error) {
-	return nil, nil
+func (hg HardwareClient) IsHealthy(context.Context) bool {
+	return true
 }
 
 // ByIP mocks the retrieval a piece of hardware from tink/cacher by ip
@@ -26,7 +25,7 @@ func (hg HardwareClient) All(_ context.Context, _ ...grpc.CallOption) (hardware.
 // having to parse the (mock) hardware data `HardwareClient.Data`, the process has been simplified to only match with the constant `UserIP`.
 // Given any other IP inside the get request, ByIP will return an empty piece of hardware regardless of whether or not the IP
 // actually matches the IP inside `Data`.
-func (hg HardwareClient) ByIP(_ context.Context, ip string, _ ...grpc.CallOption) (hardware.Hardware, error) {
+func (hg HardwareClient) ByIP(_ context.Context, ip string) (hardware.Hardware, error) {
 	var hw hardware.Hardware
 	dataModelVersion := os.Getenv("DATA_MODEL_VERSION")
 	switch dataModelVersion {
@@ -52,7 +51,7 @@ func (hg HardwareClient) ByIP(_ context.Context, ip string, _ ...grpc.CallOption
 	return hw, nil
 }
 
-func (hg HardwareClient) Watch(_ context.Context, _ string, _ ...grpc.CallOption) (hardware.Watcher, error) {
+func (hg HardwareClient) Watch(context.Context, string) (hardware.Watcher, error) {
 	return nil, nil
 }
 

--- a/http-server/http_server.go
+++ b/http-server/http_server.go
@@ -99,9 +99,9 @@ func checkHardwareClientHealth() {
 	// this will have to do.
 	// Note that we don't do anything with the stream (we don't read from it)
 	var isHardwareClientAvailableTemp bool
-	ctx, cancel := context.WithCancel(context.Background())
-	_, err := hegelServer.HardwareClient().All(ctx) // checks for tink health as well
-	if err == nil {
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	if hegelServer.HardwareClient().IsHealthy(ctx) {
 		isHardwareClientAvailableTemp = true
 	}
 	cancel()
@@ -118,6 +118,6 @@ func checkHardwareClientHealth() {
 		metrics.CacherConnected.Set(0)
 		metrics.CacherHealthcheck.WithLabelValues("false").Inc()
 		metrics.Errors.WithLabelValues("cacher", "healthcheck").Inc()
-		logger.With("status", isHardwareClientAvailableTemp).Error(err)
+		logger.With("status", isHardwareClientAvailableTemp).Error(errors.New("client reported unhealthy"))
 	}
 }


### PR DESCRIPTION
### Context

To compliment the [Kubeification of Tinkerbell's back-end](https://github.com/tinkerbell/proposals/tree/main/proposals/0026) we need to provide a mechanism for supplying hardware data from the Kubernetes API Server in Hegel.

### Changes

The hardware client is used to interact with a Cacher service and the Tink service. It embodies gRPC specific types and an ambiguous All() call that are difficult to model for a Kubernetes data provider.

This change alters the interface to model more generic behavior and removes gRPC specific types paving the path for implementing a Kubernetes data provider client that can plug into existing business logic.

This change doesn't alter any service behavior.