### PR TITLE
Wire cobra into Hegel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,14 @@ binary := cmd/hegel
 
 all: build
 
-.PHONY: ${binary}
+.PHONY: ${binary} build
 ${binary}: 
 build:
-	CGO_ENABLED=0 GOOS=$$GOOS go build -ldflags="-X main.GitRev=$(shell git rev-parse --short HEAD)" -o hegel ./cmd/hegel
+	CGO_ENABLED=0 GOOS=$$GOOS go build -ldflags="-X build.gitRevision=$(shell git rev-parse --short HEAD)" -o hegel ./cmd/hegel
+
+.PHONY: unit-test
+unit-test:
+	go test $(GO_TEST_ARGS) -coverprofile=unit-test.coverage ./...
 
 .PHONY: image
 image:

--- a/build/build.go
+++ b/build/build.go
@@ -1,0 +1,11 @@
+// Package build contains build specific information.
+package build
+
+// gitRevision is injected at build time.
+var gitRevision string
+
+// GetGitRevision retrieves the revision injected into the build at build time.
+// Deprecated. Removed when moving to 1.18 in favor of runtime/debug.ReadBuildInfo().
+func GetGitRevision() string {
+	return gitRevision
+}

--- a/cmd/hegel/Dockerfile
+++ b/cmd/hegel/Dockerfile
@@ -1,7 +1,17 @@
-FROM golang:1.17.5-alpine
-COPY . /usr/myapp
-WORKDIR /usr/myapp
-RUN mkdir -p bin && go build -o ./bin ./...
+FROM golang:1.17.5-alpine AS builder
+
+ARG GOPROXY=https://proxy.golang.org,direct
+
+RUN apk add --update --upgrade git make
+WORKDIR /src
+ENV GOPROXY=$GOPROXY
+
+# Copy only the go mod files so we can take advantage of image layer caching.
+COPY go.* ./
+RUN go mod download
+
+COPY . .
+RUN make
 
 FROM alpine:3.7
 
@@ -13,4 +23,4 @@ RUN apk add --update --upgrade ca-certificates
 RUN adduser -D -u 1000 tinkerbell
 USER tinkerbell
 
-COPY --from=0 /usr/myapp/bin/hegel /usr/bin/hegel
+COPY --from=builder /src/hegel /usr/bin/hegel

--- a/cmd/hegel/main.go
+++ b/cmd/hegel/main.go
@@ -1,95 +1,18 @@
 package main
 
 import (
-	"context"
-	"flag"
-	_ "net/http/pprof" //nolint:gosec // G108: Profiling endpoint is automatically exposed on /debug/pprof
+	"fmt"
 	"os"
-	"os/signal"
-	"sync"
-	"syscall"
-	"time"
-
-	"github.com/equinix-labs/otel-init-go/otelinit"
-	"github.com/packethost/pkg/env"
-	"github.com/packethost/pkg/log"
-	grpcserver "github.com/tinkerbell/hegel/grpc-server"
-	httpserver "github.com/tinkerbell/hegel/http-server"
-	"github.com/tinkerbell/hegel/metrics"
-)
-
-var (
-	GitRev          string
-	logger          log.Logger
-	customEndpoints string
 )
 
 func main() {
-	flag.Parse()
-	// setup structured logging
-	l, err := log.Init("github.com/tinkerbell/hegel")
+	root, err := NewRootCommand()
 	if err != nil {
-		logger.Fatal(err)
-	}
-	logger = l.Package("main")
-	defer l.Close()
-	metrics.Init(l)
-
-	ctx := context.Background()
-	ctx, otelShutdown := otelinit.InitOpenTelemetry(ctx, "hegel")
-	defer otelShutdown(ctx)
-
-	metrics.State.Set(metrics.Initializing)
-
-	hegelServer, err := grpcserver.NewServer(l, nil)
-	if err != nil {
-		logger.Fatal(err, "failed to create hegel server")
+		fmt.Fprintf(os.Stderr, "%v", err)
+		os.Exit(1)
 	}
 
-	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
-	var ret error
-	ctx, cancel := context.WithCancel(context.TODO())
-	var once sync.Once
-	var wg sync.WaitGroup
-	customEndpoints = env.Get("CUSTOM_ENDPOINTS", `{"/metadata":".metadata.instance"}`)
-
-	runGoroutine(&ret, cancel, &once, &wg, func() error {
-		return httpserver.Serve(logger, hegelServer, GitRev, time.Now(), customEndpoints)
-	})
-
-	runGoroutine(&ret, cancel, &once, &wg, func() error {
-		return grpcserver.Serve(ctx, logger, hegelServer)
-	})
-	runGoroutine(&ret, cancel, &once, &wg, func() error {
-		select {
-		case sig, ok := <-c:
-			if ok {
-				l.With("signal", sig).Info("received stop signal, gracefully shutting down")
-				cancel()
-			}
-		case <-ctx.Done():
-		}
-		return nil
-	})
-	l.Info("waiting")
-	wg.Wait()
-	if ret != nil {
-		logger.Fatal(ret)
+	if err := root.Execute(); err != nil {
+		os.Exit(1)
 	}
-}
-
-func runGoroutine(ret *error, cancel context.CancelFunc, once *sync.Once, wg *sync.WaitGroup, fn func() error) {
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		err := fn()
-		if err != nil {
-			// we only care about the first error
-			once.Do(func() {
-				*ret = err
-				cancel()
-			})
-		}
-	}()
 }

--- a/datamodel/datamodel.go
+++ b/datamodel/datamodel.go
@@ -1,12 +1,11 @@
-/*
-Package datamodel defines constants for the various back-end storage mechanisms supported by hegel.
-*/
+// Package datamodel defines constants for the various back-end storage mechanisms supported by hegel.
 package datamodel
 
 // DataModel defines the mechanism for back-end data retrieval.
 type DataModel string
 
 const (
+	Cacher     DataModel = ""
 	TinkServer DataModel = "1"
 	Kubernetes DataModel = "kubernetes"
 )

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/itchyny/gojq v0.11.0
+	github.com/oklog/run v1.1.0
 	github.com/packethost/cacher v0.0.0-20211110202753-9b918bf0fe6d
 	github.com/packethost/pkg v0.0.0-20211110202003-387414657e83
 	github.com/packethost/xff v0.0.0-20190305172552-d3e9190c41b3

--- a/go.sum
+++ b/go.sum
@@ -436,6 +436,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWb
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
+github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=
+github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=

--- a/grpc-server/grpc_helpers_test.go
+++ b/grpc-server/grpc_helpers_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/packethost/pkg/grpc"
 	"github.com/packethost/pkg/log"
 	assert "github.com/stretchr/testify/require"
+	"github.com/tinkerbell/hegel/datamodel"
 	"github.com/tinkerbell/hegel/grpc/protos/hegel"
 	"github.com/tinkerbell/hegel/hardware"
 	ggrpc "google.golang.org/grpc"
@@ -103,10 +104,10 @@ func startServersAndConnectClient(t *testing.T, d map[string]string, err error) 
 	// This is a Hegel
 	name = "hegel"
 	l := log.Test(zt, name)
-	hg, err := hardware.NewCacherClient(cClient)
+	hg, err := hardware.NewCacherClient(cClient, datamodel.Cacher)
 	assert.NoError(t, err)
-	hegelServer, err := NewServer(l, hg)
-	assert.NoError(t, err)
+	hegelServer := NewServer(l, hg)
+
 	server, err := grpc.NewServer(l, func(s *grpc.Server) {
 		hegel.RegisterHegelServer(s.Server(), hegelServer)
 	})

--- a/grpc-server/grpc_server_test.go
+++ b/grpc-server/grpc_server_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
-	"os"
 	"reflect"
 	"sync"
 	"testing"
@@ -18,12 +17,8 @@ import (
 )
 
 func TestGetCacher(t *testing.T) {
-	dataModelVersion := os.Getenv("DATA_MODEL_VERSION")
-	defer os.Setenv("DATA_MODEL_VERSION", dataModelVersion)
-
 	for name, test := range cacherGrpcTests {
 		t.Log(name)
-		os.Unsetenv("DATA_MODEL_VERSION")
 
 		l, err := log.Init("github.com/tinkerbell/hegel")
 		if err != nil {
@@ -31,10 +26,8 @@ func TestGetCacher(t *testing.T) {
 		}
 		logger := l.Package("grpcserver")
 
-		hegelTestServer, err := NewServer(logger, mock.HardwareClient{Data: test.json})
-		if err != nil {
-			t.Fatal(err, "failed to create hegel server")
-		}
+		hegelTestServer := NewServer(logger, mock.HardwareClient{Data: test.json})
+
 		addr, err := net.ResolveTCPAddr("tcp", mock.UserIP+":80")
 		if err != nil {
 			t.Fatal(err, "failed to resolve tcp addr")
@@ -97,10 +90,6 @@ func TestGetCacher(t *testing.T) {
 }
 
 func TestGetByIPTinkerbell(t *testing.T) {
-	dataModelVersion := os.Getenv("DATA_MODEL_VERSION")
-	defer os.Setenv("DATA_MODEL_VERSION", dataModelVersion)
-	os.Setenv("DATA_MODEL_VERSION", "1")
-
 	for name, test := range tinkerbellGrpcTests {
 		t.Log(name)
 
@@ -110,10 +99,7 @@ func TestGetByIPTinkerbell(t *testing.T) {
 		}
 		logger := l.Package("grpcserver")
 
-		hegelTestServer, err := NewServer(logger, mock.HardwareClient{Data: test.json})
-		if err != nil {
-			t.Fatal(err, "failed to create hegel server")
-		}
+		hegelTestServer := NewServer(logger, mock.HardwareClient{Data: test.json})
 
 		addr, err := net.ResolveTCPAddr("tcp", mock.UserIP+":80")
 		if err != nil {

--- a/hardware/mock/mock.go
+++ b/hardware/mock/mock.go
@@ -3,17 +3,19 @@ package mock
 import (
 	"context"
 	"encoding/json"
-	"errors"
-	"os"
+	"fmt"
 
 	"github.com/packethost/cacher/protos/cacher"
+	"github.com/pkg/errors"
+	"github.com/tinkerbell/hegel/datamodel"
 	"github.com/tinkerbell/hegel/hardware"
 )
 
 // HardwareClient is a mock implementation of the hardwareGetter interface
 // Data represents the hardware data stored inside tink db.
 type HardwareClient struct {
-	Data string
+	Model datamodel.DataModel
+	Data  string
 }
 
 func (hg HardwareClient) IsHealthy(context.Context) bool {
@@ -26,29 +28,26 @@ func (hg HardwareClient) IsHealthy(context.Context) bool {
 // Given any other IP inside the get request, ByIP will return an empty piece of hardware regardless of whether or not the IP
 // actually matches the IP inside `Data`.
 func (hg HardwareClient) ByIP(_ context.Context, ip string) (hardware.Hardware, error) {
-	var hw hardware.Hardware
-	dataModelVersion := os.Getenv("DATA_MODEL_VERSION")
-	switch dataModelVersion {
-	case "1":
-		hw = &hardware.Tinkerbell{}
-
+	switch hg.Model {
+	case datamodel.TinkServer:
+		fmt.Printf("HELLO WORLD\n")
 		if ip != UserIP {
-			return hw, errors.New("rpc error: code = Unknown desc = unexpected end of JSON input")
+			return nil, errors.Errorf("received non-mock remote ip address: %v", ip)
 		}
 
-		err := json.Unmarshal([]byte(hg.Data), hw)
-		if err != nil {
+		hw := &hardware.Tinkerbell{}
+		if err := json.Unmarshal([]byte(hg.Data), hw); err != nil {
 			return nil, err
 		}
+
+		return hw, nil
 	default:
 		if ip != UserIP {
-			return &hardware.Cacher{}, errors.New("rpc error: code = Unknown desc = DB is not ready")
+			return &hardware.Cacher{}, errors.Errorf("received non-mock remote ip address: %v", ip)
 		}
 
-		hw = &hardware.Cacher{Hardware: &cacher.Hardware{JSON: hg.Data}}
+		return &hardware.Cacher{Hardware: &cacher.Hardware{JSON: hg.Data}}, nil
 	}
-
-	return hw, nil
 }
 
 func (hg HardwareClient) Watch(context.Context, string) (hardware.Watcher, error) {

--- a/xff/xff.go
+++ b/xff/xff.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"os"
 	"strings"
 
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
@@ -97,10 +96,9 @@ func updateRemote(ctx context.Context, l log.Logger, masks []net.IPNet) context.
 	return ctx
 }
 
-func ParseTrustedProxies() []string {
+func ParseTrustedProxies(trustedProxies string) []string {
 	var result []string
 
-	trustedProxies := os.Getenv("TRUSTED_PROXIES")
 	for _, cidr := range strings.Split(trustedProxies, ",") {
 		cidr = strings.TrimSpace(cidr)
 		if cidr == "" {


### PR DESCRIPTION
## Overview

Builds on #84.

Wire Cobra into the business logic and strip the existing environment reads and flag parsing from the code base centralizing configuration. In wiring the CLI with the business logic I took the liberty of removing the `runGoroutine` function in favor of a small, self-contained library called `oklog/run`. Its only purpose is to manage sets of goroutines that should run collectively like those created during a main process (see root_cmd.go). There are no changes to existing behavior.

Patched a bug where the http server never shuts down after the container receives an interrupt/termination signal.

Additionally, I've rejigged the Dockerfile to take advantage of image layer caching having experienced difficulty when operating on corporate networks.

## How has this been tested?

Unit tests pass and the service run up stand-alone.