### PR TITLE
Split hardware clients into logical source files

### DIFF
--- a/hardware/cacher.go
+++ b/hardware/cacher.go
@@ -1,0 +1,98 @@
+package hardware
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/packethost/cacher/protos/cacher"
+	"github.com/pkg/errors"
+	"github.com/tinkerbell/hegel/datamodel"
+)
+
+type clientCacher struct {
+	client cacher.CacherClient
+}
+
+type Cacher struct {
+	*cacher.Hardware
+}
+
+type watcherCacher struct {
+	client cacher.Cacher_WatchClient
+}
+
+// NewCacherClient returns a new hardware Client, configured to use a provided cacher Client
+// This function is primarily used for testing.
+func NewCacherClient(cc cacher.CacherClient, model datamodel.DataModel) (Client, error) {
+	if model != "" {
+		return nil, errors.New("NewCacherClient is only valid for the cacher data model")
+	}
+
+	return clientCacher{client: cc}, nil
+}
+
+func (hg clientCacher) IsHealthy(ctx context.Context) bool {
+	_, err := hg.client.All(ctx, &cacher.Empty{})
+	return err == nil
+}
+
+// ByIP retrieves from Cacher the piece of hardware with the specified IP.
+func (hg clientCacher) ByIP(ctx context.Context, ip string) (Hardware, error) {
+	in := &cacher.GetRequest{
+		IP: ip,
+	}
+	hw, err := hg.client.ByIP(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	return &Cacher{hw}, nil
+}
+
+// Watch returns a Cacher watch client on the hardware with the specified ID.
+func (hg clientCacher) Watch(ctx context.Context, id string) (Watcher, error) {
+	in := &cacher.GetRequest{
+		ID: id,
+	}
+	w, err := hg.client.Watch(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	return &watcherCacher{w}, nil
+}
+
+// Export formats the piece of hardware to be returned in responses to clients.
+func (hw *Cacher) Export() ([]byte, error) {
+	exported := &ExportedCacher{}
+
+	err := json.Unmarshal([]byte(hw.JSON), exported)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(exported)
+}
+
+// ID returns the hardware ID.
+func (hw *Cacher) ID() (string, error) {
+	hwJSON := make(map[string]interface{})
+	err := json.Unmarshal([]byte(hw.JSON), &hwJSON)
+	if err != nil {
+		return "", err
+	}
+
+	hwID := hwJSON["id"]
+	id, ok := hwID.(string)
+	if !ok {
+		return "", errors.Errorf("hwID is %T, not a string", hwID)
+	}
+
+	return id, err
+}
+
+// Recv receives a piece of hardware from the Cacher watch client.
+func (w *watcherCacher) Recv() (Hardware, error) {
+	hw, err := w.client.Recv()
+	if err != nil {
+		return nil, err
+	}
+	return &Cacher{hw}, nil
+}

--- a/hardware/tink.go
+++ b/hardware/tink.go
@@ -1,0 +1,70 @@
+package hardware
+
+import (
+	"context"
+	"encoding/json"
+
+	tinkpkg "github.com/tinkerbell/tink/pkg"
+	"github.com/tinkerbell/tink/protos/hardware"
+)
+
+type Tinkerbell struct {
+	*hardware.Hardware
+}
+
+type clientTinkerbell struct {
+	client hardware.HardwareServiceClient
+}
+
+type watcherTinkerbell struct {
+	client hardware.HardwareService_DeprecatedWatchClient
+}
+
+// All retrieves all the pieces of hardware stored in Cacher.
+func (hg clientTinkerbell) IsHealthy(ctx context.Context) bool {
+	_, err := hg.client.All(ctx, &hardware.Empty{})
+	return err == nil
+}
+
+// ByIP retrieves from Tink the piece of hardware with the specified IP.
+func (hg clientTinkerbell) ByIP(ctx context.Context, ip string) (Hardware, error) {
+	in := &hardware.GetRequest{
+		Ip: ip,
+	}
+	hw, err := hg.client.ByIP(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	return &Tinkerbell{hw}, nil
+}
+
+// Watch returns a Tink watch client on the hardware with the specified ID.
+func (hg clientTinkerbell) Watch(ctx context.Context, id string) (Watcher, error) {
+	in := &hardware.GetRequest{
+		Id: id,
+	}
+	w, err := hg.client.DeprecatedWatch(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	return &watcherTinkerbell{w}, nil
+}
+
+// Export formats the piece of hardware to be returned in responses to clients.
+func (hw *Tinkerbell) Export() ([]byte, error) {
+	return json.Marshal(tinkpkg.HardwareWrapper(*hw))
+}
+
+// ID returns the hardware ID.
+func (hw *Tinkerbell) ID() (string, error) {
+	return hw.Id, nil
+}
+
+// Recv receives a piece of hardware from the Tink watch client.
+func (w *watcherTinkerbell) Recv() (Hardware, error) {
+	hw, err := w.client.Recv()
+	if err != nil {
+		return nil, err
+	}
+	return &Tinkerbell{hw}, nil
+}


### PR DESCRIPTION
Builds on #82 

The hardware clients has 3 implementations with a fourth, file based for testing, being written. This change introduces a simple source file split to reduce cognitive load.