### PR TITLE
Make kubernetes API URL optional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,15 @@ binary := cmd/hegel
 all: unit-test image
 
 .PHONY: ${binary} build
-${binary}: 
+${binary}:
 build:
 	CGO_ENABLED=0 GOOS=$$GOOS go build -ldflags="-X build.gitRevision=$(shell git rev-parse --short HEAD)" -o hegel ./cmd/hegel
 
 .PHONY: unit-test
 unit-test:
 	go test $(GO_TEST_ARGS) -coverprofile=unit-test.coverage ./...
+
+IMAGE_ARGS ?= -t hegel
 
 .PHONY: image
 image:

--- a/cmd/hegel/root_cmd.go
+++ b/cmd/hegel/root_cmd.go
@@ -271,8 +271,8 @@ func (c *RootCommand) validateOpts() error {
 		}
 	}
 	if c.Opts.GetDataModel() == datamodel.Kubernetes {
-		if c.Opts.Kubeconfig == "" {
-			return errors.Errorf("--data-model=%v requires --kubeconfig", datamodel.Kubernetes)
+		if c.Opts.Kubeconfig == "" && c.Opts.KubernetesAPIURL == "" {
+			return errors.Errorf("--data-model=%v requires --kubeconfig or --kubernetes", datamodel.Kubernetes)
 		}
 	}
 

--- a/hardware/client.go
+++ b/hardware/client.go
@@ -60,12 +60,8 @@ func (v ClientConfig) validate() error {
 	}
 
 	if v.Model == datamodel.Kubernetes {
-		if v.KubeAPI == "" {
-			return errors.New("kubernetes data model: kube api url is required")
-		}
-
-		if v.Kubeconfig == "" {
-			return errors.New("kubernetes data model: kubeconfig path is required")
+		if v.KubeAPI == "" && v.Kubeconfig == "" {
+			return errors.New("kubernetes data model: kubernetes API URL or kubeconfig is required")
 		}
 	}
 


### PR DESCRIPTION
## Description

* Add default container image tag

Signed-off-by: Micah Hausler <mhausler@amazon.com>

## Why is this needed

* setting `--kubernetes` without `--kubeconfig` is required for in-cluster clients, and setting only a `--kubeconfig` is also valid.
* `make image` should produce an image with a tag without having to specify any arguments

## How are existing users impacted? What migration steps/scripts do we need?

N/A

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
