### PR TITLE
include boot drive hint in instance struct

### DIFF
--- a/hardware/export.go
+++ b/hardware/export.go
@@ -31,9 +31,10 @@ type instance struct {
 
 	CryptedRootPassword string `json:"crypted_root_password,omitempty"`
 
-	Storage      *storage `json:"storage,omitempty"`
-	SSHKeys      []string `json:"ssh_keys,omitempty"`
-	NetworkReady bool     `json:"network_ready,omitempty"`
+	Storage       *storage `json:"storage,omitempty"`
+	SSHKeys       []string `json:"ssh_keys,omitempty"`
+	NetworkReady  bool     `json:"network_ready,omitempty"`
+	BootDriveHint string   `json:"boot_drive_hint,omitempty"`
 }
 
 type operatingSystem struct {

--- a/hardware/export.go
+++ b/hardware/export.go
@@ -31,6 +31,7 @@ type instance struct {
 
 	CryptedRootPassword string `json:"crypted_root_password,omitempty"`
 
+	StorageSource string   `json:"storage_source,omitempty"`
 	Storage       *storage `json:"storage,omitempty"`
 	SSHKeys       []string `json:"ssh_keys,omitempty"`
 	NetworkReady  bool     `json:"network_ready,omitempty"`


### PR DESCRIPTION
## Description

boot_drive_hint is a field provided in cacher to hint at which drive
should be used for the boot drive.

This field already is used by boots when building the vmware config,
however is now being used in osie and needs to be exported.

Reference to boots: https://github.com/tinkerbell/boots/blob/c670ca8c03d5e7c4b951cac56724d21331fb7568/client/instance.go#L42

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
