### PR TITLE
Default to in-cluster config and remove kube config requirements

### DIFF
--- a/cmd/hegel/root_cmd.go
+++ b/cmd/hegel/root_cmd.go
@@ -270,11 +270,6 @@ func (c *RootCommand) validateOpts() error {
 			return errors.New("--grpc-use-tls requires --grpc-tls-key")
 		}
 	}
-	if c.Opts.GetDataModel() == datamodel.Kubernetes {
-		if c.Opts.Kubeconfig == "" && c.Opts.KubernetesAPIURL == "" {
-			return errors.Errorf("--data-model=%v requires --kubeconfig or --kubernetes", datamodel.Kubernetes)
-		}
-	}
 
 	return nil
 }

--- a/hardware/client.go
+++ b/hardware/client.go
@@ -59,12 +59,6 @@ func (v ClientConfig) validate() error {
 		}
 	}
 
-	if v.Model == datamodel.Kubernetes {
-		if v.KubeAPI == "" && v.Kubeconfig == "" {
-			return errors.New("kubernetes data model: kubernetes API URL or kubeconfig is required")
-		}
-	}
-
 	return nil
 }
 

--- a/hardware/kubernetes.go
+++ b/hardware/kubernetes.go
@@ -136,17 +136,16 @@ type KubernetesClientConfig struct {
 
 // NewKubernetesClientConfig loads the kubeconfig overriding it with kubeAPI.
 func NewKubernetesClientConfig(kubeconfig, kubeAPI string) (KubernetesClientConfig, error) {
-	kubeClientCfg := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-		&clientcmd.ClientConfigLoadingRules{
-			ExplicitPath: kubeconfig,
-		},
-		&clientcmd.ConfigOverrides{
-			ClusterInfo: clientcmdapi.Cluster{
-				Server: kubeAPI,
-			},
-		},
-	)
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	loadingRules.ExplicitPath = kubeconfig
 
+	overrides := &clientcmd.ConfigOverrides{
+		ClusterInfo: clientcmdapi.Cluster{
+			Server: kubeAPI,
+		},
+	}
+
+	kubeClientCfg := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, overrides)
 	config, err := kubeClientCfg.ClientConfig()
 	if err != nil {
 		return KubernetesClientConfig{}, err


### PR DESCRIPTION
The Kubernetes configuration currently required via the CLI isn't strictly required. If we aren't in-cluster and nothing was supplied it will naturally fail on loading. This change removes the checks entirely and lets the client creation process error out naturally.