### PR TITLE
Add kubernetes namespace override

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ certs/
 out/
 *.coverage
 /hegel
+.vscode

--- a/cmd/hegel/root_cmd.go
+++ b/cmd/hegel/root_cmd.go
@@ -75,6 +75,7 @@ type RootCommandOptions struct {
 
 	KubernetesAPIURL string `mapstructure:"kubernetes"`
 	Kubeconfig       string `mapstructure:"kubeconfig"`
+	KubeNamespace    string `mapstructure:"kube-namespace"`
 }
 
 func (o RootCommandOptions) GetDataModel() datamodel.DataModel {
@@ -145,10 +146,11 @@ func (c *RootCommand) Run(cmd *cobra.Command, _ []string) error {
 	metrics.State.Set(metrics.Initializing)
 
 	hardwareClient, err := hardware.NewClient(hardware.ClientConfig{
-		Model:      c.Opts.GetDataModel(),
-		Facility:   c.Opts.Facility,
-		KubeAPI:    c.Opts.KubernetesAPIURL,
-		Kubeconfig: c.Opts.Kubeconfig,
+		Model:         c.Opts.GetDataModel(),
+		Facility:      c.Opts.Facility,
+		KubeAPI:       c.Opts.KubernetesAPIURL,
+		Kubeconfig:    c.Opts.Kubeconfig,
+		KubeNamespace: c.Opts.KubeNamespace,
 	})
 	if err != nil {
 		return errors.Errorf("create client: %v", err)
@@ -210,6 +212,7 @@ func (c *RootCommand) configureFlags() error {
 
 	c.Flags().String("kubeconfig", "", "Path to a kubeconfig file")
 	c.Flags().String("kubernetes", "", "URL of the Kubernetes API Server")
+	c.Flags().String("kube-namespace", "", "The Kubernetes namespace to target; defaults to the service account")
 
 	c.Flags().String("trusted-proxies", "", "A commma separated list of allowed peer IPs and/or CIDR blocks to replace with X-Forwarded-For for both gRPC and HTTP endpoints")
 

--- a/hardware/client.go
+++ b/hardware/client.go
@@ -44,12 +44,16 @@ type ClientConfig struct {
 	Facility string
 
 	// KubeAPI is the URL of the Kube API the Kubernetes client talks to.
-	// Required for datamodel.Kubernetes.
+	// Optional
 	KubeAPI string
 
 	// Kuberconfig is a path to a Kubeconfig file used by the Kubernetes client.
-	// Required for datamodel.Kubernetes.
+	// Optional
 	Kubeconfig string
+
+	// KubeNamespace is a namespace override to have Hegel use for reading resources.
+	// Optional
+	KubeNamespace string
 }
 
 func (v ClientConfig) validate() error {
@@ -70,7 +74,7 @@ func NewClient(config ClientConfig) (Client, error) {
 
 	switch config.Model {
 	case datamodel.Kubernetes:
-		config, err := NewKubernetesClientConfig(config.Kubeconfig, config.KubeAPI)
+		config, err := NewKubernetesClientConfig(config.Kubeconfig, config.KubeAPI, config.KubeNamespace)
 		if err != nil {
 			return nil, errors.Errorf("loading kubernetes config: %v", err)
 		}

--- a/hardware/kubernetes.go
+++ b/hardware/kubernetes.go
@@ -135,13 +135,16 @@ type KubernetesClientConfig struct {
 }
 
 // NewKubernetesClientConfig loads the kubeconfig overriding it with kubeAPI.
-func NewKubernetesClientConfig(kubeconfig, kubeAPI string) (KubernetesClientConfig, error) {
+func NewKubernetesClientConfig(kubeconfig, kubeAPI, namespace string) (KubernetesClientConfig, error) {
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
 	loadingRules.ExplicitPath = kubeconfig
 
 	overrides := &clientcmd.ConfigOverrides{
 		ClusterInfo: clientcmdapi.Cluster{
 			Server: kubeAPI,
+		},
+		Context: clientcmdapi.Context{
+			Namespace: namespace,
 		},
 	}
 
@@ -151,7 +154,7 @@ func NewKubernetesClientConfig(kubeconfig, kubeAPI string) (KubernetesClientConf
 		return KubernetesClientConfig{}, err
 	}
 
-	namespace, _, err := kubeClientCfg.Namespace()
+	namespace, _, err = kubeClientCfg.Namespace()
 	if err != nil {
 		return KubernetesClientConfig{}, err
 	}


### PR DESCRIPTION
When launching Hegel in Kubernetes it can default, if no Kubeconfig is specified, to using the ServiceAccount configured with the Pod. The ServiceAccount is the same as the Pod deployment namespace and consequently Hegel defaults to reading from its own namespace. This isn't always desirable as users may want to place the `Hardware` custom resource in a different namespace.

By defaulting to in-cluster config and requiring an operator to configure RBAC and explicitly set the `--kube-namespace` override we have a 'secure and predictable' out of the box deployment model.