### PR TITLE
Handle gRPC shutdown from context cancel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ IMAGE_ARGS ?= -t hegel
 
 .PHONY: image
 image:
-	docker build $(IMAGE_ARGS) -f ./cmd/hegel/Dockerfile .
+	docker build --build-arg GOPROXY=$(GOPROXY) $(IMAGE_ARGS) -f ./cmd/hegel/Dockerfile .
 
 .PHONY: gen
 gen: grpc/protos/hegel/hegel.pb.go


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
This fixes an issue where a single ctrl-c to hegel doesn't shutdown the gRPC server and requires another ctrl-c in order for hegel to exit at all. This causes deployments into envs like Kubernetes to have to be force-ably killed in order to shutdown.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
