### PR TITLE
Convert _packet urls to z-pages

### DIFF
--- a/http/server.go
+++ b/http/server.go
@@ -33,8 +33,8 @@ func Serve(
 	var httpHandler http.Handler
 
 	mux.Handle("/metrics", promhttp.Handler())
-	mux.Handle("/_packet/healthcheck", HealthCheckHandler(logger, client, start))
-	mux.Handle("/_packet/version", VersionHandler(logger))
+	mux.Handle("/healthz", HealthCheckHandler(logger, client, start))
+	mux.Handle("/versionz", VersionHandler(logger))
 
 	if !hegelAPI {
 		ec2MetadataHandler := otelhttp.WithRouteTag("/2009-04-04", EC2MetadataHandler(logger, client))

--- a/http/server_test.go
+++ b/http/server_test.go
@@ -820,12 +820,12 @@ func TestServe(t *testing.T) {
 		{
 			name:    "serve_endpoint_success",
 			status:  200,
-			httpreq: "/_packet/version",
+			httpreq: "/versionz",
 		},
 		{
 			name:    "serve_endpoint_failed",
 			status:  404,
-			httpreq: "/_packet/version12",
+			httpreq: "/version12",
 		},
 	}
 	mport := 52000


### PR DESCRIPTION
Change `/_packet` endpoints to [z-pages](https://stackoverflow.com/questions/43380939/where-does-the-convention-of-using-healthz-for-application-health-checks-come-f).

Closes #133 