### PR TITLE
Refactor release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,8 +1,8 @@
+name: Release
 on:
   push:
     tags:
       - "v*"
-name: Create release
 
 env:
   REGISTRY: quay.io

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,13 +10,13 @@ env:
 
 jobs:
   release:
+    name: Release
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Login to quay.io
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         if: ${{ startsWith(github.ref, 'refs/heads/main') }}
         with:
           registry: ${{ env.REGISTRY }}
@@ -25,18 +25,20 @@ jobs:
 
       # This action generates the source image name and should coincide with the build
       # from the ci.yaml workflow.
-      - name: Generate source image
+      - name: Generate source image name
         id: src
         uses: docker/metadata-action@v4
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           images: ${{ env.IMAGE }}
           flavor: latest=false
           tags: type=sha
 
-      - name: Generate docker tags
+      - name: Generate image release tags
         id: meta
         uses: docker/metadata-action@v4
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           images: ${{ env.IMAGE }}
           flavor: latest=false
           tags: |
@@ -51,24 +53,17 @@ jobs:
           dst: |
             ${{ steps.meta.outputs.tags }}
 
-      - name: Generate release notes
-        run: |
-          release_notes=$(gh api repos/{owner}/{repo}/releases/generate-notes -F tag_name=${{ github.ref }} --jq .body)
-          echo 'RELEASE_NOTES<<EOF' >> $GITHUB_ENV
-          echo "${release_notes}" >> $GITHUB_ENV
-          echo 'EOF' >> $GITHUB_ENV
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OWNER: ${{ github.repository_owner }}
-          REPO: ${{ github.event.repository.name }}
-
-      - name: Create release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Publish release
+        uses: ncipollo/release-action@v1
         with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
-          body: ${{ env.RELEASE_NOTES }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          artifactErrorsFailBuild: true
+          generateReleaseNotes: true
           draft: true
-          prerelease: true
+          prerelease: ${{ contains(github.ref_name, '-rc') }}
+          body: |
+            ## Image
+
+            ```
+            docker pull quay.io/tinkerbell/hegel:${{ github.ref_name }}
+            ````


### PR DESCRIPTION
The [`actions/create-release`](https://github.com/actions/create-release) Github action has been archived. This change set moves to a different action that creates releases in a similar way to the current process.

The action used to create releases is https://github.com/ncipollo/release-action. 

I tested the release workflow with a tag pushed to the Hegel repository and everything works fine. [Successful run can be found under actions](https://github.com/tinkerbell/hegel/actions/runs/3394585868).