### PR TITLE
Remove conditional login on release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,6 @@ jobs:
 
       - name: Login to quay.io
         uses: docker/login-action@v2
-        if: ${{ startsWith(github.ref, 'refs/heads/main') }}
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.QUAY_USERNAME }}


### PR DESCRIPTION
Stop conditionally logging into quay.io on release workflows.

Release workflows are gated on tags so the need to gate the login is superfluous and leads to misleading 400 Bad Request errors from quay.io. 