### PR TITLE
Fix mergify settings for auto merge

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -3,8 +3,8 @@ queue_rules:
     conditions:
       # Conditions to get out of the queue (= merged)
       - check-success=DCO
-      # The docker-images job only runs if lint, build and test all pass.
-      - check-success=images
+      # The package job only runs if lint, build and test all pass.
+      - check-success=package
 
 pull_request_rules:
   - name: Automatic merge on approval
@@ -14,8 +14,8 @@ pull_request_rules:
       - "#changes-requested-reviews-by=0"
       - "#review-requested=0"
       - check-success=DCO
-      # The docker-images job only runs if lint, build and test all pass.
-      - check-success=images
+      # The package job only runs if lint, build and test all pass.
+      - check-success=package
       - label!=do-not-merge
       - label=ready-to-merge
     actions:


### PR DESCRIPTION
The CI image building job was recently changed to `package` in conjunction with other CI refactors. This updates the mergify settings to require the `package` job to finish before a PR can be auto merged.