### PR TITLE
Add e2e tests for Hegel root cmd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,10 @@ build: ## Build the Hegel binary. Use GOOS and GOARCH to set the target OS and a
 test: ## Run unit tests.
 	go test $(GO_TEST_ARGS) -coverprofile=coverage.out ./...
 
+.PHONY: test-e2e
+test-e2e:
+	go test $(GO_TEST_ARGS) -tags=e2e ./e2e
+
 # When we build the image its Linux based. This means we need a Linux binary hence we need to export
 # GOOS so we have compatible binary.
 .PHONY: image

--- a/cmd/hegel/main.go
+++ b/cmd/hegel/main.go
@@ -3,10 +3,12 @@ package main
 import (
 	"fmt"
 	"os"
+
+	"github.com/tinkerbell/hegel/internal/cmd"
 )
 
 func main() {
-	root, err := NewRootCommand()
+	root, err := cmd.NewRootCommand()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%v", err)
 		os.Exit(1)

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -1,0 +1,96 @@
+//go:build e2e
+
+package e2e_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/tinkerbell/hegel/internal/cmd"
+)
+
+func TestHegel_EC2Frontend(t *testing.T) {
+	// Build the root command so we can launch it as if a main() func would.
+	root, err := cmd.NewRootCommand()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	root.SetArgs([]string{
+		// Use the flatfile backend to limit our dependencies. We're really focused on ensuring
+		// the root cmd strings together properly so this should be fine.
+		"--backend", "flatfile",
+		"--flatfile-path", "testdata/e2e.yml",
+
+		// We need to trust the localhost so we can impersonate machines in requests.
+		"--trusted-proxies", "127.0.0.1",
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go root.ExecuteContext(ctx)
+
+	// Ensure the cmd goroutine is scheduled (by leaning on continuation behavior of the runtime)
+	// and begins listening. Slower machines may need a longer delay.
+	time.Sleep(50 * time.Millisecond)
+
+	t.Run("APIs", func(t *testing.T) {
+		// We have unit tests to validate the APIs serve correct data. These tests are to validate
+		// a static endpoint and a dynamic endpoint work as expected.
+		cases := []struct {
+			Name     string
+			Endpoint string
+			Expect   string
+		}{
+			{
+				Name:     "StaticRoute",
+				Endpoint: "/2009-04-04",
+				Expect: `meta-data/
+user-data/`,
+			},
+			{
+				Name:     "DynamicRoute",
+				Endpoint: "/2009-04-04/meta-data/hostname",
+				Expect:   "hostname",
+			},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.Name, func(t *testing.T) {
+				request, err := http.NewRequest(
+					http.MethodGet,
+					"http://127.0.0.1:50061"+tc.Endpoint,
+					nil,
+				)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				// Impersonate the target instance.
+				request.Header.Add("X-Forwarded-For", "10.10.10.10")
+
+				response, err := http.DefaultClient.Do(request)
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer response.Body.Close()
+
+				// Store the body in a buffer for comparison.
+				var buf bytes.Buffer
+				_, err = io.Copy(&buf, response.Body)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if buf.String() != tc.Expect {
+					t.Fatalf("Expected:\n%s\n\nReceived:\n%s\n", tc.Expect, buf.String())
+				}
+			})
+		}
+	})
+}

--- a/e2e/testdata/e2e.yml
+++ b/e2e/testdata/e2e.yml
@@ -1,0 +1,20 @@
+- userdata: "test"
+  metadata:
+    id: "instanceid"
+    hostname: "hostname"
+    localHostname: "localhostname"
+    iqn: "iqn"
+    plan: "plan"
+    facility: "facility"
+    tags: ["foo", "bar"]
+    ipv4:
+      local: "10.10.10.11"
+      public: "10.10.10.10"
+    ipv6:
+      public: "2001:db8:0:1:1:1:1:1"
+    os:
+      slug: "slug"
+      distro: "distro"
+      version: "version"
+      imageTag: "imagetag"
+      licenseActivationState: "licenseactivationstate"

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -1,4 +1,4 @@
-package main
+package cmd
 
 import (
 	"fmt"


### PR DESCRIPTION
Builds on #155.

We have very little automated coverage ensuring the root cmd strings together properly. This change introduces an e2e package that builds and launches the root Hegel command as if a `main()` function would, then runs a few basic tests to ensure it serves data correctly.

The tests are not run as part of the unit test suite and must be invoked with the `-tags=e2e` argument to `go test` as it leverages go build commands to limit how its included.