### PR TITLE
Extract buildinfo from debug information

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,6 @@ build: ## Build the Hegel binary. Use GOOS and GOARCH to set the target OS and a
 	GOOS=$$GOOS \
 	GOARCH=$$GOARCH \
 	go build \
-		-ldflags="-X build.gitRevision=$(shell git rev-parse --short HEAD)" \
 		-o hegel-$(GOOS)-$(GOARCH) \
 		./cmd/hegel
 

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -1,11 +1,38 @@
 // Package build contains build specific information.
 package build
 
+import (
+	"runtime/debug"
+	"strconv"
+)
+
 // gitRevision is injected at build time.
 var gitRevision string
 
-// GetGitRevision retrieves the revision injected into the build at build time.
-// Deprecated. Removed when moving to 1.18 in favor of runtime/debug.ReadBuildInfo().
+func init() {
+	var (
+		revision string
+		dirty    bool
+	)
+
+	info, _ := debug.ReadBuildInfo()
+	for _, i := range info.Settings {
+		switch {
+		case i.Key == "vcs.revision":
+			revision = i.Value
+		case i.Key == "vcs.modified":
+			dirty, _ = strconv.ParseBool(i.Value)
+		}
+	}
+
+	gitRevision = revision
+	if dirty {
+		gitRevision += "-dirty"
+	}
+}
+
+// GetGitRevision retrieves the revision of the current build. If the build contains uncommitted
+// changes the revision will be suffixed with "-dirty".
 func GetGitRevision() string {
 	return gitRevision
 }


### PR DESCRIPTION
Update the `/internal/build` to retrieve the vcs revision from builtin build information instead of injecting it. 

This simplifies our build process/compilation command as we no longer need to set symbols and can have a more reliable way of determining "dirty" builds.