### PR TITLE
Fix handling of trailing slash in ec2 frontend

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -119,7 +119,6 @@ func (c *RootCommand) Run(cmd *cobra.Command, _ []string) error {
 
 	router := gin.New()
 	router.Use(gin.Logger(), gin.Recovery(), xffmw)
-	router.RedirectTrailingSlash = true
 
 	zpages.Configure(router, be)
 

--- a/internal/frontend/ec2/frontend.go
+++ b/internal/frontend/ec2/frontend.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/gin-gonic/gin"
+	"github.com/tinkerbell/hegel/internal/ginutil"
 	"github.com/tinkerbell/hegel/internal/http/httperror"
 	"github.com/tinkerbell/hegel/internal/http/request"
 )
@@ -40,9 +41,9 @@ func New(client Client) Frontend {
 // TODO(chrisdoherty4) Document unimplemented endpoints.
 func (f Frontend) Configure(router gin.IRouter) {
 	// Setup the 2009-04-04 API path prefix.
-	v20090404 := router.Group("/2009-04-04")
+	v20090404 := ginutil.TrailingSlashRouteHelper{IRouter: router.Group("/2009-04-04")}
 
-	dynamicEndpointBinder := func(router *gin.RouterGroup, endpoint string, filter filterFunc) {
+	dynamicEndpointBinder := func(router gin.IRouter, endpoint string, filter filterFunc) {
 		router.GET(endpoint, func(ctx *gin.Context) {
 			instance, err := f.getInstance(ctx, ctx.Request)
 			if err != nil {
@@ -68,7 +69,7 @@ func (f Frontend) Configure(router gin.IRouter) {
 		dynamicEndpointBinder(v20090404, route.Endpoint, route.Filter)
 	}
 
-	staticEndpointBinder := func(router *gin.RouterGroup, endpoint string, childEndpoints []string) {
+	staticEndpointBinder := func(router gin.IRouter, endpoint string, childEndpoints []string) {
 		router.GET(endpoint, func(ctx *gin.Context) {
 			ctx.String(http.StatusOK, join(childEndpoints))
 		})

--- a/internal/ginutil/router.go
+++ b/internal/ginutil/router.go
@@ -1,0 +1,34 @@
+package ginutil
+
+import (
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+// TrailingSlashRouteHelper wraps a gin.IRouter and ensures every route registered with GET
+// has a corresponding alternate route with or without, dependent on the endpoint being registered,
+// a trailing slash.
+type TrailingSlashRouteHelper struct {
+	gin.IRouter
+}
+
+// GET overrides the internal gin.IRouter GET. It interrogates endpoint for a trailing slash. If
+// no trailing slash is present, it registers the endpoint and a corresponding endpoint with a
+// trailing slash using the same handler. If it does end in a trailing slash, it does the inverse.
+func (r TrailingSlashRouteHelper) GET(endpoint string, handler ...gin.HandlerFunc) gin.IRoutes {
+	// Determine if the alternate endpoint should end with a slash or have it stripped.
+	// This ensures we don't have routes such as
+	// 		/2009-04-04/meta-data/instance-id/
+	// 		/2009-04-04/meta-data/instance-id//
+	var alternateEndpoint string
+	if strings.HasSuffix(endpoint, "/") {
+		alternateEndpoint = strings.TrimSuffix(endpoint, "/")
+	} else {
+		alternateEndpoint = endpoint + "/"
+	}
+
+	return r.IRouter.
+		GET(endpoint, handler...).
+		GET(alternateEndpoint, handler...)
+}

--- a/internal/ginutil/router_test.go
+++ b/internal/ginutil/router_test.go
@@ -1,0 +1,74 @@
+package ginutil_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	. "github.com/tinkerbell/hegel/internal/ginutil"
+)
+
+func TestTrailingSlashRouteHelper(t *testing.T) {
+	cases := []struct {
+		Name      string
+		Endpoint  string
+		Alternate string
+	}{
+		{
+			Name:      "NoTrailingSlash",
+			Endpoint:  "/foo",
+			Alternate: "/foo/",
+		},
+		{
+			Name:      "TrailingSlash",
+			Endpoint:  "/foo/",
+			Alternate: "/foo",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			router := TrailingSlashRouteHelper{gin.New()}
+
+			// Create a variable that is the gin.Engine so we can call ServeHTTP on it as IRouter
+			// doesn't have that API.
+			servable := router.IRouter.(*gin.Engine)
+
+			// Cache the total number of calls.
+			var calls int
+
+			// Configure the route. This should result in the alternate route being registered to.
+			router.GET(tc.Endpoint, func(ctx *gin.Context) {
+				calls++
+				ctx.Writer.WriteHeader(http.StatusOK)
+			})
+
+			endpointRequest := httptest.NewRequest(http.MethodGet, tc.Endpoint, nil)
+			endpointResponse := httptest.NewRecorder()
+
+			servable.ServeHTTP(endpointResponse, endpointRequest)
+
+			if endpointResponse.Code != http.StatusOK {
+				t.Fatalf("Expected status code: %d; Received: %d", http.StatusOK, endpointResponse.Code)
+			}
+
+			if calls != 1 {
+				t.Fatalf("Expected calls: 1; Received: %d", calls)
+			}
+
+			alternateRequest := httptest.NewRequest(http.MethodGet, tc.Alternate, nil)
+			alternateResponse := httptest.NewRecorder()
+
+			servable.ServeHTTP(alternateResponse, alternateRequest)
+
+			if alternateResponse.Code != http.StatusOK {
+				t.Fatalf("Expected status code: %d; Received: %d", http.StatusOK, alternateResponse.Code)
+			}
+
+			if calls != 2 {
+				t.Fatalf("Expected calls: 2; Received: %d", calls)
+			}
+		})
+	}
+}


### PR DESCRIPTION
cloud-init queries endpoints that nest other endpoints with a trailing slash. Without registering duplicate routes with trailing slashes Hegel will return a 404. This change ensures routes with both a trailing slash and not are registered for the EC2 frontend.

Fixes #163 