### PR TITLE
Increase dependabot limit for gomod

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,7 @@ updates:
       day: "sunday"
       time: "05:00"
       timezone: "America/New_York"
+    open-pull-requests-limit: 10
 
   - package-ecosystem: "docker"
     directory: "/"


### PR DESCRIPTION
Increase gomod dependency update limit given the significant number of dependencies and the fact it runs weekly.