### PR TITLE
Handle server error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@ GOARCH ?= $(shell go env GOARCH)
 # Specify the target OS to build the binary for. (Recipes: build)
 GOOS ?= $(shell go env GOOS)
 
+# Specify the GOPROXYs to use in the build of the binary. (Recipes: build, image)
+GOPROXY ?= $(shell go env GOPROXY)
+
 # Specify additional `docker build` arguments. (Recipes: image)
 IMAGE_ARGS ?= -t hegel
 
@@ -19,6 +22,7 @@ build: ## Build the Hegel binary. Use GOOS and GOARCH to set the target OS and a
 	CGO_ENABLED=0 \
 	GOOS=$$GOOS \
 	GOARCH=$$GOARCH \
+	GOPROXY=$$GOPROXY \
 	go build \
 		-o hegel-$(GOOS)-$(GOARCH) \
 		./cmd/hegel
@@ -36,7 +40,7 @@ test-e2e: ## Run E2E tests.
 .PHONY: image
 image: export GOOS=linux
 image: build ## Build a Linux based Hegel image for the the host architecture.
-	docker build --build-arg GOPROXY=$(GOPROXY) $(IMAGE_ARGS) .
+	docker build --build-arg TARGETARCH=$(GOARCH) --build-arg TARGETOS=$(GOOS) $(IMAGE_ARGS) .
 
 # The command to run mockgen.
 MOCKGEN = go run github.com/golang/mock/mockgen@v1.6

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ GOARCH ?= $(shell go env GOARCH)
 # Specify the target OS to build the binary for. (Recipes: build)
 GOOS ?= $(shell go env GOOS)
 
-# Specify the GOPROXYs to use in the build of the binary. (Recipes: build, image)
+# Specify the GOPROXYs to use in the build of the binary. (Recipes: build)
 GOPROXY ?= $(shell go env GOPROXY)
 
 # Specify additional `docker build` arguments. (Recipes: image)
@@ -40,7 +40,7 @@ test-e2e: ## Run E2E tests.
 .PHONY: image
 image: export GOOS=linux
 image: build ## Build a Linux based Hegel image for the the host architecture.
-	docker build --build-arg TARGETARCH=$(GOARCH) --build-arg TARGETOS=$(GOOS) $(IMAGE_ARGS) .
+	DOCKER_BUILDKIT=1 docker build $(IMAGE_ARGS) .
 
 # The command to run mockgen.
 MOCKGEN = go run github.com/golang/mock/mockgen@v1.6

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -28,7 +28,6 @@ func Serve(ctx context.Context, logger log.Logger, address string, handler http.
 	go func() {
 		logger.Info(fmt.Sprintf("Listening on %s", address))
 		if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			logger.Info(err.Error())
 			errChan <- err
 		}
 	}()

--- a/internal/http/server_test.go
+++ b/internal/http/server_test.go
@@ -60,16 +60,13 @@ func TestServerFailure(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
-	var mux http.ServeMux
-	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprint(w, "Hello, world!")
-	})
 	n, err := net.Listen("tcp", ":8181")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer n.Close()
-	if err := Serve(ctx, logger, fmt.Sprintf(":%d", 8181), &mux); err == nil {
+
+	if err := Serve(ctx, logger, fmt.Sprintf(":%d", 8181), &http.ServeMux{}); err == nil {
 		t.Fatal("expected error")
 	}
 }


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
Return when `server.ListenAndServe()` fails in `http.Serve`. 

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #191 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
