### PR TITLE
Remove redundant .envrc file

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,7 +1,0 @@
-which nix &>/dev/null && use nix
-unset GOPATH
-
-#export GO111MODULE=on
-export GOBIN=$(pwd)/bin${GOBIN:+:$GOBIN}
-#export GOFLAGS=-mod=vendor
-export PATH=$(pwd)/bin:$PATH


### PR DESCRIPTION
Remove redundant `.envrc` file. This file was used in conjunction with NixOS which isn't used in Hegel any longer.