### PR TITLE
Add FAQ on /metadata endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ curl -H "X-Forwarded-For: 10.10.10.10" http://localhost:50061/2009-04-04/meta-da
 ### What is the `/metadata` endpoint
 
 Historically, `/metadata` (which is different to the EC2 `/2009-04-04/meta-data` endpoint) has
-provided [Equinix Metal Metadata][equinix-metadata]. It exists in Hegel versions <= v9.x. In v10
+provided [Equinix Metal Metadata][equinix-metadata]. It exists in Hegel versions <= v0.9. In v0.10
 it was deprecated _and_ removed. 
 
 If you have a need for different metadata formats please raise an issue.

--- a/README.md
+++ b/README.md
@@ -69,5 +69,14 @@ docker run --rm -d --name=hegel \
 curl -H "X-Forwarded-For: 10.10.10.10" http://localhost:50061/2009-04-04/meta-data/hostname
 ```
 
+### What is the `/metadata` endpoint
+
+Historically, `/metadata` (which is different to the EC2 `/2009-04-04/meta-data` endpoint) has
+provided [Equinix Metal Metadata][equinix-metadata]. It exists in Hegel versions <= v9.x. In v10
+it was deprecated _and_ removed. 
+
+If you have a need for different metadata formats please raise an issue.
+
 [cloud-init]: https://cloudinit.readthedocs.io/en/latest/
 [ignition]: https://coreos.github.io/ignition/
+[equinix-metadata]: https://deploy.equinix.com/developers/docs/metal/server-metadata/metadata/


### PR DESCRIPTION
The `/metadata` endpoint is being removed in v10+ having identified that no-one except Equinix have historically used it and that Equinix are moving away from Hegel. We have received and continue to receive questions on the `/metadata` endpoint asking what its meant to provide so an FAQ is helpful to point people at.

Closes #188 