### PR TITLE
Add a hack frontend for rootio action

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,8 +26,6 @@ require (
 	sigs.k8s.io/controller-runtime v0.13.1
 )
 
-require github.com/kr/pretty v0.3.1 // indirect
-
 require (
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
@@ -61,6 +59,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/kr/pretty v0.3.1 // indirect
 	github.com/leodido/go-urn v1.2.1 // indirect
 	github.com/magiconair/properties v1.8.6 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -8,6 +8,7 @@ import (
 	"github.com/tinkerbell/hegel/internal/backend/flatfile"
 	"github.com/tinkerbell/hegel/internal/backend/kubernetes"
 	"github.com/tinkerbell/hegel/internal/frontend/ec2"
+	"github.com/tinkerbell/hegel/internal/frontend/hack"
 	"github.com/tinkerbell/hegel/internal/healthcheck"
 )
 
@@ -21,6 +22,7 @@ var ErrMultipleBackends = errors.New("only one backend option can be specified")
 // this interface.
 type Client interface {
 	ec2.Client
+	hack.Client
 	healthcheck.Client
 }
 

--- a/internal/backend/flatfile/hack.go
+++ b/internal/backend/flatfile/hack.go
@@ -1,0 +1,13 @@
+package flatfile
+
+import (
+	"context"
+	"errors"
+
+	"github.com/tinkerbell/hegel/internal/frontend/hack"
+)
+
+// GetHackInstance exists to satisfy the hack.Client interface. It is not implemented.
+func (b *Backend) GetHackInstance(context.Context, string) (hack.Instance, error) {
+	return hack.Instance{}, errors.New("unsupported")
+}

--- a/internal/backend/kubernetes/hack.go
+++ b/internal/backend/kubernetes/hack.go
@@ -1,0 +1,36 @@
+package kubernetes
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/tinkerbell/hegel/internal/frontend/hack"
+	tinkv1 "github.com/tinkerbell/tink/pkg/apis/core/v1alpha1"
+)
+
+func (b *Backend) GetHackInstance(ctx context.Context, ip string) (hack.Instance, error) {
+	hw, err := b.retrieveByIP(ctx, ip)
+	if err != nil {
+		return hack.Instance{}, err
+	}
+
+	return toHackInstance(hw)
+}
+
+// toHackInstance converts a Tinkerbell Hardware resource to a hack.Instance by marshalling and
+// unmarshalling. This works because the Hardware resource has historical roots that align with
+// the hack.Instance struct that is derived from the rootio action. See the hack frontend for more
+// details.
+func toHackInstance(hw tinkv1.Hardware) (hack.Instance, error) {
+	marshalled, err := json.Marshal(hw.Spec)
+	if err != nil {
+		return hack.Instance{}, err
+	}
+
+	var i hack.Instance
+	if err := json.Unmarshal(marshalled, &i); err != nil {
+		return hack.Instance{}, err
+	}
+
+	return i, nil
+}

--- a/internal/e2e/e2e_test.go
+++ b/internal/e2e/e2e_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/tinkerbell/hegel/internal/cmd"
 )
 
-func TestHegel_EC2Frontend(t *testing.T) {
+func TestHegel(t *testing.T) {
 	// Build the root command so we can launch it as if a main() func would.
 	root, err := cmd.NewRootCommand()
 	if err != nil {
@@ -39,7 +39,7 @@ func TestHegel_EC2Frontend(t *testing.T) {
 	// and begins listening. Slower machines may need a longer delay.
 	time.Sleep(50 * time.Millisecond)
 
-	t.Run("APIs", func(t *testing.T) {
+	t.Run("EC2", func(t *testing.T) {
 		// We have unit tests to validate the APIs serve correct data. These tests are to validate
 		// a static endpoint and a dynamic endpoint work as expected.
 		cases := []struct {

--- a/internal/frontend/hack/hack.go
+++ b/internal/frontend/hack/hack.go
@@ -1,0 +1,69 @@
+/*
+Package hack contains a frontend that provides a /metadata endpoint for the rootio hub action.
+It is not intended to be long lived and will be removed as we migrate to exposing Hardware
+data to Tinkerbell templates. In doing so, we can convert the rootio action to accept its inputs
+via parameters instead of retrieing them from Hegel and subsequently delete this frontend.
+*/
+package hack
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/tinkerbell/hegel/internal/http/request"
+)
+
+// Client is a backend for retrieving hack instance data.
+type Client interface {
+	GetHackInstance(ctx context.Context, ip string) (Instance, error)
+}
+
+// Instance is a representation of the instance metadata. Its based on the rooitio hub action
+// and should have just enough information for it to work.
+type Instance struct {
+	Metadata struct {
+		Instance struct {
+			Storage struct {
+				Disks []struct {
+					Device     string `json:"device"`
+					Partitions []struct {
+						Label  string `json:"label"`
+						Number int    `json:"number"`
+						Size   uint64 `json:"size"`
+					} `json:"partitions"`
+					WipeTable bool `json:"wipe_table"`
+				} `json:"disks"`
+				Filesystems []struct {
+					Mount struct {
+						Create struct {
+							Options []string `json:"options"`
+						} `json:"create"`
+						Device string `json:"device"`
+						Format string `json:"format"`
+						Point  string `json:"point"`
+					} `json:"mount"`
+				} `json:"filesystems"`
+			} `json:"storage"`
+		} `json:"instance"`
+	} `json:"metadata"`
+}
+
+// Configure configures router with a `/metadata` endpoint using client to retrieve instance data.
+func Configure(router gin.IRouter, client Client) {
+	router.GET("/metadata", func(ctx *gin.Context) {
+		ip, err := request.RemoteAddrIP(ctx.Request)
+		if err != nil {
+			_ = ctx.AbortWithError(http.StatusBadRequest, errors.New("invalid remote address"))
+		}
+
+		instance, err := client.GetHackInstance(ctx, ip)
+		if err != nil {
+			_ = ctx.AbortWithError(http.StatusInternalServerError, err)
+			return
+		}
+
+		ctx.JSON(200, instance)
+	})
+}


### PR DESCRIPTION
The rootio action is dependent on the Hegel `/metadata` endpoint; it requires storage device metadata only. This PR adds the `/metadata` endpoint back to Hegel temporarily until we migrate to exposing hardware data during Tinkerbell Template rendering where the rootio action will be passed its data as parameters.

The code lives in a new `hack` frontend to make clear its a hacky thing and with commentary on when it should be deleted.

The `/metadata` endpoint was tested by launching a K3D cluster and then launching Hegel manually. A Hardware was submitted to the cluster and the `/metadata` endpoint curled. 

Relates to #188 