### PR TITLE
Close YAML file handle when parsing flatfile backend

### DIFF
--- a/internal/backend/flatfile/yaml.go
+++ b/internal/backend/flatfile/yaml.go
@@ -30,6 +30,7 @@ func FromYAMLFile(path string) (*Backend, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer fh.Close()
 
 	return FromYAML(fh)
 }


### PR DESCRIPTION
This PR is equivalent to https://github.com/tinkerbell/hegel/pull/217.

It closes the YAML file ensuring we don't leak handles.