### PR TITLE
Fix binary permissions as part of Github actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -117,6 +117,10 @@ jobs:
         with:
           name: hegel
 
+      # The upload/download actions do not preserve permissions so they need explicitly setting.
+      - name: Fix binary permissions
+        run: chmod +x hegel-linux-*
+
       - name: Generate image tags
         uses: docker/metadata-action@v4
         id: meta

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,11 +12,6 @@ RUN apk add --update --upgrade --no-cache ca-certificates && \
 
 COPY ./hegel-$TARGETOS-$TARGETARCH /usr/bin/hegel
 
-# Github's artifact upload action doesn't preserve permissions. While this is a Github specific
-# problem, there's no succinct way to fix it in the actions as we build for multiple platforms.
-# For now, we'll suffer the extra layer and just chmod the binary.
-RUN chmod +x /usr/bin/hegel
-
 # Switching to the tinkerbell user should be done as late as possible so we still use root to
 # perform the other commands.
 USER tinkerbell


### PR DESCRIPTION
Move `chmod` from Dockerfile to Github actions (should've done this in the first place, oops).