### PR TITLE
Point the latest image tag at the latest release

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -127,9 +127,9 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           images: ${{ env.IMAGE }}
+          flavor: latest=false
           tags: |
             type=sha
-            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Login to quay.io
         uses: docker/login-action@v2

--- a/.github/workflows/latest.yaml
+++ b/.github/workflows/latest.yaml
@@ -1,0 +1,25 @@
+# Latest updates the :latest tag for the quay.io/tinkerbell/hegel image to the latest release.
+# The latest release is controlled by maintainers as defined by Github's 'latest release' flag
+# on releases and can be generally defined as the latest major.minor.patch.
+#
+# Given this workflow is triggered when a release is published or edited, it is susceptible
+# to being overtriggered. The workflow operates on the assumption that a published release has
+# an associated docker image.
+name: Latest
+on:
+  release:
+    types: [published, edited]
+
+env:
+  IMAGE: quay.io/${{ github.repository }}
+
+jobs:
+  latest:
+    name: Update latest image tag
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          LATEST=$(curl -H "Accept: application/json" https://api.github.com/repos/tinkerbell/hegel/releases/latest | jq .name -r)
+          docker pull {{ env.IMAGE }}:$LATEST
+          docker tag {{ env.IMAGE }}:$LATEST {{ env.IMAGE }}:latest
+          docker push {{ env.IMAGE }}:latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,8 +22,8 @@ jobs:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
 
-      # This action generates the source image name and should coincide with the build
-      # from the ci.yaml workflow.
+      # This step generates the source image name and should coincide with the build from the
+      # ci.yaml workflow.
       - name: Generate source image name
         id: src
         uses: docker/metadata-action@v4


### PR DESCRIPTION
This PR ensures the `:latest` image tag always points to the latest release unlike the current setup that doesn't have clear semantics for `:latest` (it flips between main and release builds).

The expectation is that a release will be published but not necessarily marked as 'latest' in Github. A maintainer will at some undetermined time change the latest release which should trigger. The new workflow is triggered when a release is published and when a release is edited ensuring that if a release is published as latest the tag is updated and if a release is later edited to be latest the tag is updated.