### PR TITLE
Auto approve dependabot PRs

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -5,36 +5,45 @@ shared:
   # Rules applicable to both queueing and merge requests.
   compulsory: &compulsory
 
-    # Ensure the minimal CI checks have passed.
-    - check-success=DCO
-    - check-success=Package
+  # Ensure the minimal CI checks have passed.
+  - check-success=DCO
+  - check-success=Package
 
-    # Ensure we're targetting the default branch.
-    - base=main
+  # Ensure we're targetting the default branch.
+  - base=main
 
-    # Ensure we have adequete reviews.
-    - "#approved-reviews-by>=1"
-    - "#changes-requested-reviews-by=0"
+  # Ensure we have adequete reviews.
+  - "#approved-reviews-by>=1"
+  - "#changes-requested-reviews-by=0"
 
 queue_rules:
-  - name: default
-    conditions:
-      - and: *compulsory
+- name: default
+  conditions:
+  - and: *compulsory
 
 pull_request_rules:
-  - name: Automatic merge
-    conditions:
-      - and: *compulsory
+- name: Automatic merge
+  conditions:
+  - and: *compulsory
 
-      # Ensure the review is opted in using labels.
-      - label!=do-not-merge
-      - label=ready-to-merge
+  # Ensure the review is opted in using labels.
+  - label!=do-not-merge
+  - label=ready-to-merge
 
-    actions:
-      queue:
-        method: merge
-        name: default
-        commit_message_template: |
-          {{ title }} (#{{ number }})
+  actions:
+    queue:
+      method: merge
+      name: default
+      commit_message_template: |
+        {{ title }} (#{{ number }})
 
-          {{ body }}
+        {{ body }}
+
+- name: Automatic dependabot approval
+  conditions:
+  - author=dependabot[bot]
+  actions:
+    review:
+      type: APPROVE
+      message: Automatically approving dependabot
+  priority: 3000


### PR DESCRIPTION
## Summary

Dependabot raises lots of updates (which is good). We require PRs to be approved before they can be merged. This auto approves dependabot PRs and leaves it to maintainers to handle the merge.