### PR TITLE
Refactor backend opts

### DIFF
--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -39,7 +39,7 @@ func New(ctx context.Context, opts Options) (Client, error) {
 		return flatfile.FromYAMLFile(opts.Flatfile.Path)
 
 	case opts.Kubernetes != nil:
-		kubeclient, err := kubernetes.NewBackend(ctx, kubernetes.BackendConfig{
+		kubeclient, err := kubernetes.NewBackend(ctx, kubernetes.Config{
 			Kubeconfig:       opts.Kubernetes.Kubeconfig,
 			APIServerAddress: opts.Kubernetes.APIServerAddress,
 			Namespace:        opts.Kubernetes.Namespace,
@@ -61,8 +61,8 @@ func New(ctx context.Context, opts Options) (Client, error) {
 // Options contains all options for all backend implementations. Only one backend option can be
 // specified at a time.
 type Options struct {
-	Flatfile   *FlatfileOptions
-	Kubernetes *KubernetesOptions
+	Flatfile   *Flatfile
+	Kubernetes *kubernetes.Config
 }
 
 func (o Options) validate() error {
@@ -84,22 +84,7 @@ func (o Options) validate() error {
 }
 
 // FlatFileOptions is the configuration for a flatfile backend.
-type FlatfileOptions struct {
+type Flatfile struct {
 	// Path is a path to a YAML file containing a list of flatfile instances.
 	Path string
-}
-
-// KubernetesOptions is the configuration for a Kubernetes backend.
-type KubernetesOptions struct {
-	// APIServerAddress is the URL of the Kube API the Kubernetes client talks to.
-	// Optional
-	APIServerAddress string
-
-	// Kuberconfig is a path to a Kubeconfig file used by the Kubernetes client.
-	// Optional
-	Kubeconfig string
-
-	// KubeNamespace is a namespace override to have Hegel use for reading resources.
-	// Optional
-	Namespace string
 }

--- a/internal/backend/backend_test.go
+++ b/internal/backend/backend_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	. "github.com/tinkerbell/hegel/internal/backend"
+	"github.com/tinkerbell/hegel/internal/backend/kubernetes"
 )
 
 func TestNew(t *testing.T) {
@@ -17,8 +18,8 @@ func TestNew(t *testing.T) {
 		{
 			Name: "OnlyOneBackend",
 			Options: Options{
-				Flatfile:   &FlatfileOptions{},
-				Kubernetes: &KubernetesOptions{},
+				Flatfile:   &Flatfile{},
+				Kubernetes: &kubernetes.Config{},
 			},
 			Error: ErrMultipleBackends,
 		},

--- a/internal/backend/kubernetes/backend.go
+++ b/internal/backend/kubernetes/backend.go
@@ -37,7 +37,7 @@ type Backend struct {
 // NewBackend creates a new Backend instance. It launches a goroutine to perform synchronization
 // between the cluster and internal caches. Consumers can wait for the initial sync using WaitForCachesync().
 // See k8s.io/Backend-go/tools/Backendcmd for constructing *rest.Config objects.
-func NewBackend(ctx context.Context, cfg BackendConfig) (*Backend, error) {
+func NewBackend(ctx context.Context, cfg Config) (*Backend, error) {
 	// If no client was specified, build one and configure the backend with it including waiting
 	// for the caches to sync.
 	if cfg.ClientConfig == nil {
@@ -83,7 +83,7 @@ func NewBackend(ctx context.Context, cfg BackendConfig) (*Backend, error) {
 	}, nil
 }
 
-func loadConfig(cfg BackendConfig) (BackendConfig, error) {
+func loadConfig(cfg Config) (Config, error) {
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
 	loadingRules.ExplicitPath = cfg.Kubeconfig
 
@@ -99,7 +99,7 @@ func loadConfig(cfg BackendConfig) (BackendConfig, error) {
 	loader := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, overrides)
 	config, err := loader.ClientConfig()
 	if err != nil {
-		return BackendConfig{}, err
+		return Config{}, err
 	}
 	cfg.ClientConfig = config
 
@@ -107,7 +107,7 @@ func loadConfig(cfg BackendConfig) (BackendConfig, error) {
 	// namespace was loaded from the kubeconfig.
 	namespace, _, err := loader.Namespace()
 	if err != nil {
-		return BackendConfig{}, err
+		return Config{}, err
 	}
 	cfg.Namespace = namespace
 

--- a/internal/backend/kubernetes/backend_integration_test.go
+++ b/internal/backend/kubernetes/backend_integration_test.go
@@ -112,7 +112,7 @@ func TestBackend(t *testing.T) {
 	defer cancel()
 
 	// Construct the backend and attempt to retrieve our test Hardware resource.
-	backend, err := NewBackend(ctx, BackendConfig{ClientConfig: cfg})
+	backend, err := NewBackend(ctx, Config{ClientConfig: cfg})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/backend/kubernetes/config.go
+++ b/internal/backend/kubernetes/config.go
@@ -4,8 +4,8 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-// BackendConfig used by the NewBackend function family.
-type BackendConfig struct {
+// Config used by the NewBackend function family.
+type Config struct {
 	// Kubeconfig is a path to a valid kubeconfig file. When in-cluster defaults to the in-cluster
 	// config. Optional.
 	Kubeconfig string

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -17,6 +17,7 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"github.com/tinkerbell/hegel/internal/backend"
+	"github.com/tinkerbell/hegel/internal/backend/kubernetes"
 	"github.com/tinkerbell/hegel/internal/frontend/ec2"
 	"github.com/tinkerbell/hegel/internal/frontend/hack"
 	"github.com/tinkerbell/hegel/internal/healthcheck"
@@ -29,8 +30,8 @@ import (
 const longHelp = `
 Run a Hegel server.
 
-Each CLI argument has a corresponding environment variable in the form of the CLI argument prefixed 
-with HEGEL. If both the flag and environment variable form are specified, the flag form takes 
+Each CLI argument has a corresponding environment variable in the form of the CLI argument prefixed
+with HEGEL. If both the flag and environment variable form are specified, the flag form takes
 precedence.
 
 Examples
@@ -196,13 +197,13 @@ func toBackendOptions(opts RootCommandOptions) backend.Options {
 	switch opts.Backend {
 	case "flatfile":
 		backndOpts = backend.Options{
-			Flatfile: &backend.FlatfileOptions{
+			Flatfile: &backend.Flatfile{
 				Path: opts.FlatfilePath,
 			},
 		}
 	case "kubernetes":
 		backndOpts = backend.Options{
-			Kubernetes: &backend.KubernetesOptions{
+			Kubernetes: &kubernetes.Config{
 				APIServerAddress: opts.KubernetesAPIServer,
 				Kubeconfig:       opts.KubernetesKubeconfig,
 				Namespace:        opts.KubernetesNamespace,


### PR DESCRIPTION
Reduce duplicate config data structures and open up all backend option to the Kubernetes backend by using the already available config data structure.