### PR TITLE
Change dependency update frequency to once a week

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,25 +16,13 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-      day: "monday"
+      day: "friday"
       time: "03:52"
       timezone: "America/New_York"
     reviewers:
       - chrisdoherty4
       - jacobweinstock
-    open-pull-requests-limit: 10
-
-  - package-ecosystem: "gomod"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-      day: "thursday"
-      time: "03:52"
-      timezone: "America/New_York"
-    reviewers:
-      - chrisdoherty4
-      - jacobweinstock
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 20
 
   - package-ecosystem: "docker"
     directory: "/"


### PR DESCRIPTION
Projects tend to release once a week so more frequent updates are redundant. Unless there's a serious CVE (which can be manually patched) we don't need higher frequency.