### PR TITLE
Patch incorrect local IPv4 address

### DIFF
--- a/internal/backend/kubernetes/backend.go
+++ b/internal/backend/kubernetes/backend.go
@@ -186,17 +186,17 @@ func toEC2Instance(hw tinkv1.Hardware) ec2.Instance {
 		for _, ip := range hw.Spec.Metadata.Instance.Ips {
 			// Public IPv4
 			if ip.Family == 4 && ip.Public && i.Metadata.PublicIPv4 == "" {
-				i.Metadata.PublicIPv4 = hw.Spec.Metadata.Instance.Ips[0].Address
+				i.Metadata.PublicIPv4 = ip.Address
 			}
 
 			// Private IPv4
 			if ip.Family == 4 && !ip.Public && i.Metadata.LocalIPv4 == "" {
-				i.Metadata.LocalIPv4 = hw.Spec.Metadata.Instance.Ips[0].Address
+				i.Metadata.LocalIPv4 = ip.Address
 			}
 
 			// Public IPv6
 			if ip.Family == 6 && i.Metadata.PublicIPv6 == "" {
-				i.Metadata.PublicIPv6 = hw.Spec.Metadata.Instance.Ips[0].Address
+				i.Metadata.PublicIPv6 = ip.Address
 			}
 		}
 	}

--- a/internal/backend/kubernetes/backend_test.go
+++ b/internal/backend/kubernetes/backend_test.go
@@ -252,6 +252,66 @@ func TestGetEC2Instance(t *testing.T) {
 			},
 		},
 		{
+			Name: "PublicThenPrivateIPv4s",
+			Hardware: tinkv1.Hardware{
+				Spec: tinkv1.HardwareSpec{
+					Metadata: &tinkv1.HardwareMetadata{
+						Instance: &tinkv1.MetadataInstance{
+							Ips: []*tinkv1.MetadataInstanceIP{
+								{
+									Address: "10.10.10.10",
+									Family:  4,
+									Public:  true,
+								},
+								{
+									Address: "172.15.0.1",
+									Family:  4,
+									// Zero value is false but we want to be explicit.
+									Public: false,
+								},
+							},
+						},
+					},
+				},
+			},
+			ExpectedInstance: ec2.Instance{
+				Metadata: ec2.Metadata{
+					PublicIPv4: "10.10.10.10",
+					LocalIPv4:  "172.15.0.1",
+				},
+			},
+		},
+		{
+			Name: "PrivateThenPublicIPv4s",
+			Hardware: tinkv1.Hardware{
+				Spec: tinkv1.HardwareSpec{
+					Metadata: &tinkv1.HardwareMetadata{
+						Instance: &tinkv1.MetadataInstance{
+							Ips: []*tinkv1.MetadataInstanceIP{
+								{
+									Address: "10.10.10.10",
+									Family:  4,
+									// Zero value is false but we want to be explicit.
+									Public: false,
+								},
+								{
+									Address: "172.15.0.1",
+									Family:  4,
+									Public:  true,
+								},
+							},
+						},
+					},
+				},
+			},
+			ExpectedInstance: ec2.Instance{
+				Metadata: ec2.Metadata{
+					PublicIPv4: "172.15.0.1",
+					LocalIPv4:  "10.10.10.10",
+				},
+			},
+		},
+		{
 			Name: "PublicIPv6",
 			Hardware: tinkv1.Hardware{
 				Spec: tinkv1.HardwareSpec{


### PR DESCRIPTION
Closes #325 

When requesting the EC2 /local-ipv4 endpoint the first address was always being returned irrespective of whether a private address existed on the Hardware resource.