### PR TITLE
Look at all namespace unless overridden

### DIFF
--- a/internal/backend/kubernetes/backend.go
+++ b/internal/backend/kubernetes/backend.go
@@ -51,7 +51,9 @@ func NewBackend(ctx context.Context, cfg Config) (*Backend, error) {
 
 	conf := func(opts *cluster.Options) {
 		opts.Scheme = scheme
-		opts.Cache.DefaultNamespaces = map[string]cache.Config{cfg.Namespace: {}}
+		if cfg.Namespace != "" {
+			opts.Cache.DefaultNamespaces = map[string]cache.Config{cfg.Namespace: {}}
+		}
 	}
 
 	clstr, err := cluster.New(cfg.ClientConfig, conf)
@@ -103,14 +105,6 @@ func loadConfig(cfg Config) (Config, error) {
 		return Config{}, err
 	}
 	cfg.ClientConfig = config
-
-	// In the event no namespace was provided for override, we need to fill it in with whatever
-	// namespace was loaded from the kubeconfig.
-	namespace, _, err := loader.Namespace()
-	if err != nil {
-		return Config{}, err
-	}
-	cfg.Namespace = namespace
 
 	return cfg, nil
 }


### PR DESCRIPTION
## Description

Removes the default setting where not specifying the kubernetes-namespace defaults it to whatever namespace the controller is running in

## Why is this needed

https://github.com/tinkerbell/cluster-api-provider-tinkerbell/issues/385

With this change, you can create hardware resources in different namespaces.

Fixes: #

## How Has This Been Tested?
We have a cluster-api setup where we're adding some bare metal nodes to a cluster.
With this change, the hardware resources that previously only worked from the tink-system namespace now also work from a different namespace.  I also tested the old working setup and that still works as well.
The change is minimal, so it shouldn't impact much.
I haven't tested if the --kubernetes-namespace setting would restrict it to one namespace again.


## How are existing users impacted? What migration steps/scripts do we need?

The Role and RoleBinding resources in the helm chart (or whatever other deployment method) need to be changed to ClusterRole and ClusterRoleBinding, otherwise it will not be able to read from the other namespaces.

Otherwise no migration steps are needed, unless users have multiple instances of hegel running in different namespaces, or have another reason why they specifically don't want resources in a different namespace to be picked up.

This could probably be avoided by having the helm chart add the kubernetes-namespace argument to the deployment and have it pull the value from the downward api somehow, but it seems to me that having it default to looking at all namespaces would be preferrable for most users.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
