### PR TITLE
Handle Nil pointer error and update linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,6 +16,7 @@ linters:
     - asciicheck
     - bidichk
     - bodyclose
+    - copyloopvar
     - contextcheck
     - cyclop
     - dogsled
@@ -26,7 +27,6 @@ linters:
     - errname
     - errorlint
     - exhaustive
-    - exportloopref
     - forcetypeassert
     - gci
     - gocognit
@@ -111,9 +111,6 @@ linters-settings:
       - name: var-naming
       - name: unconditional-recursion
       - name: waitgroup-by-value
-
-  unused:
-    go: "1.21"
 
 issues:
   # Excluding configuration per-path, per-linter, per-text and per-source

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ help:
 
 # -- Tooling
 
-GOLANGCI_LINT_VERSION 	?= v1.55.2
+GOLANGCI_LINT_VERSION 	?= v1.61.0
 GOLANGCI_LINT 			:= $(TOOLS_DIR)/golangci-lint
 $(GOLANGCI_LINT):
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | \

--- a/internal/backend/flatfile/backend_test.go
+++ b/internal/backend/flatfile/backend_test.go
@@ -73,7 +73,7 @@ func TestGetEC2Instance(t *testing.T) {
 				}
 
 				if !cmp.Equal(&ec2Instance, tc.ExpectedInstance) {
-					t.Errorf(cmp.Diff(ec2Instance, tc.ExpectedInstance))
+					t.Error(cmp.Diff(ec2Instance, tc.ExpectedInstance))
 				}
 			}
 		})

--- a/internal/backend/kubernetes/backend.go
+++ b/internal/backend/kubernetes/backend.go
@@ -162,7 +162,7 @@ type listerClient interface {
 func toEC2Instance(hw tinkv1.Hardware) ec2.Instance {
 	var i ec2.Instance
 
-	if hw.Spec.Metadata.Instance != nil {
+	if hw.Spec.Metadata != nil && hw.Spec.Metadata.Instance != nil {
 		i.Metadata.InstanceID = hw.Spec.Metadata.Instance.ID
 		i.Metadata.Hostname = hw.Spec.Metadata.Instance.Hostname
 		i.Metadata.LocalHostname = hw.Spec.Metadata.Instance.Hostname
@@ -195,7 +195,7 @@ func toEC2Instance(hw tinkv1.Hardware) ec2.Instance {
 		}
 	}
 
-	if hw.Spec.Metadata.Facility != nil {
+	if hw.Spec.Metadata != nil && hw.Spec.Metadata.Facility != nil {
 		i.Metadata.Plan = hw.Spec.Metadata.Facility.PlanSlug
 		i.Metadata.Facility = hw.Spec.Metadata.Facility.FacilityCode
 	}


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
Handle Nil pointer error and update linter. As the Hardware spec.metadata and spec.metadata.instance are not required in the hardware object they could be nil. Handle checking this so we don't nil pointer panic.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
